### PR TITLE
CLI Updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,8 @@ services:
 
   cli:
     <<: *node
-    working_dir: /root/sites
-    entrypoint: ["/root/node_modules/.bin/basecms-website"]
+    working_dir: /root
+    entrypoint: ["/root/packages/cli/src/index.js"]
     environment:
       <<: *env
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@endeavorb2b/websites-cli",
+  "version": "0.0.1",
+  "description": "Website creation tool",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "solocommand <josh@limit0.io>",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "chalk": "^2.4.2",
+    "inquirer": "^6.2.2",
+    "yaml": "^1.4.0",
+    "yargs": "^13.2.2"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,9 +3,6 @@
   "version": "0.0.1",
   "description": "Website creation tool",
   "main": "src/index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "author": "solocommand <josh@limit0.io>",
   "license": "MIT",
   "private": true,

--- a/packages/cli/src/commands/create-site/index.js
+++ b/packages/cli/src/commands/create-site/index.js
@@ -1,0 +1,119 @@
+const log = require('fancy-log');
+const inquirer = require('inquirer');
+const chalk = require('chalk');
+const { existsSync, readFileSync, appendFileSync } = require('fs');
+const { spawnSync } = require('child_process');
+const yaml = require('yaml');
+
+const options = (yargs) => {
+  yargs.option('folder', {
+    describe: 'A path (relative to the CWD) to create the project in',
+    type: 'string',
+  }).option('siteName', {
+    describe: 'The friendly name of the website',
+    type: 'string',
+  }).option('account', {
+    describe: 'The account key',
+    type: 'string',
+  }).option('dev', {
+    describe: 'Add website to docker compose',
+    type: 'boolean',
+    default: true,
+  });
+};
+
+const questions = argv => [
+  {
+    name: 'folder',
+    default: argv.folder,
+    message: chalk`Project Name {reset [used as the {blue folder} for the site]}:`,
+    validate: v => RegExp(/^[a-zA-Z0-9-]{1,}$/).test(v) || chalk`Invalid: {reset [Only {green a-z} {green A-Z} {green 0-9} and {green -} allowed]}`,
+  },
+  {
+    name: 'siteName',
+    default: argv.siteName,
+    message: 'The friendly name of the website project',
+  },
+  {
+    name: 'dev',
+    default: argv.dev,
+    type: 'confirm',
+    message: 'Add website to docker compose?',
+  },
+  {
+    name: 'account',
+    default: argv.account || 'ebm',
+    message: chalk`Account Key {reset [used for the site's GraphQL URI]}:`
+  },
+  {
+    name: 'group',
+    default: argv.group,
+    message: chalk`Group Key {reset [used for the site's GraphQL URI]}:`
+  }
+];
+
+const handler = async (argv) => {
+  if (!argv.folder || !argv.account || !argv.group) {
+    await inquirer
+      .prompt(questions(argv))
+      .then(answers => Object.keys(answers).forEach(k => argv[k] = answers[k]));
+  }
+  const { folder, dev, siteName, account, group } = argv;
+  const npmOrg = 'endeavorb2b';
+  const templateDir = 'packages/website-template';
+  const graphqlUri = `https://graphql.base-cms.io/${account}/${group}`;
+
+  if (existsSync(`sites/${folder}`)) throw new Error(`Folder ${folder} already exists!`);
+
+  const args = [
+    'create',
+    `--path=${folder}`,
+    `--npmOrg=${npmOrg}`,
+    `--templateDir=${templateDir}`,
+    `--siteName=${siteName}`,
+    `--graphqlUri=${graphqlUri}`,
+    '--proceed=true',
+    '--withNavItems=true',
+    '--withBootstrap=true',
+    '--proceed=true'
+  ];
+  log('Executing basecms-website with options...');
+  const { status } = spawnSync('./node_modules/.bin/basecms-website', args, { stdio: 'inherit' });
+  if (status !== 0) throw new Error('basecms-website did not execute successfully!');
+
+  if (dev) {
+    updateDockerCompose({ folder, account, group });
+    updateTravis({ folder, siteName });
+  }
+};
+
+const updateDockerCompose = ({ folder, account, group }) => {
+  const parsed = yaml.parse(readFileSync('./docker-compose.yml', 'utf8'), { merge: true });
+  const prev = parsed.services[Object.keys(parsed.services).pop()];
+  const appPort = parseInt(prev.environment.EXPOSED_PORT) + 1;
+  const lrPort = parseInt(prev.environment.LIVERELOAD_PORT) + 1;
+
+  log('Appending docker compose configuration');
+  appendFileSync('./docker-compose.yml', `\n  ${folder}:
+  <<: *node
+  <<: *site-cmd
+  working_dir: /root/sites/${folder}
+  environment:
+    <<: *env
+    PORT: 80
+    EXPOSED_PORT: ${appPort}
+    LIVERELOAD_PORT: ${lrPort}
+    GRAPHQL_URI: https://graphql.base-cms.io/${account}/${group}
+  ports:
+    - "${appPort}:80"
+    - "${lrPort}:${lrPort}"\n`);
+};
+
+const updateTravis = ({ folder, siteName }) => {
+  log('Appending Travis deployment configuration');
+  appendFileSync('./.travis.yml', `\n    - stage: deploy
+    name: Deploy ${siteName}
+    script: scripts/deploy.js ${folder}\n`);
+};
+
+module.exports = yargs => yargs.command('create-site', 'Create a new website project', options, handler);

--- a/packages/cli/src/commands/create-site/index.js
+++ b/packages/cli/src/commands/create-site/index.js
@@ -67,15 +67,11 @@ const handler = async (argv) => {
 
   const args = [
     'create',
-    `--path=${folder}`,
-    `--npmOrg=${npmOrg}`,
-    `--templateDir=${templateDir}`,
-    `--siteName=${siteName}`,
-    `--graphqlUri=${graphqlUri}`,
-    '--proceed=true',
-    '--withNavItems=true',
-    '--withBootstrap=true',
-    '--proceed=true'
+    folder,
+    `--npm-org=${npmOrg}`,
+    `--template-dir=${templateDir}`,
+    `--site-name=${siteName}`,
+    `--graphql-uri=${graphqlUri}`,
   ];
   log('Executing basecms-website with options...');
   const { status } = spawnSync('./node_modules/.bin/basecms-website', args, { stdio: 'inherit' });

--- a/packages/cli/src/commands/index.js
+++ b/packages/cli/src/commands/index.js
@@ -1,0 +1,5 @@
+const createSite = require('./create-site');
+
+module.exports = (yargs) => {
+  createSite(yargs);
+};

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+const yargs = require('yargs');
+const log = require('fancy-log');
+
+const commands = require('./commands');
+
+const main = () => {
+  log('Starting CLI...');
+  commands(yargs);
+  yargs
+    .help()
+    .demandCommand()
+    .argv;
+};
+main();

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 docker-compose run \
   --rm \
-  cli create \
-    --npm-org=endeavorb2b \
-    $@
+  cli create-site \
+  $@

--- a/yarn.lock
+++ b/yarn.lock
@@ -579,7 +579,7 @@
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.4.2":
+"@babel/runtime@^7.3.4", "@babel/runtime@^7.4.2":
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.2.tgz#f5ab6897320f16decd855eed70b705908a313fe8"
   integrity sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==
@@ -10846,6 +10846,13 @@ yallist@^3.0.0, yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
+yaml@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.4.0.tgz#b729a3ef7e35bdc5ece8f28900e20a9b41510fc3"
+  integrity sha512-rzU83hGJrNgyT7OE2mP/SILeZxEMRJ0mza0n4KFtkNL1aXUZ79ZgZ5pIH56yT6LiqujcAs/Rqzp0ApvvNYfUfw==
+  dependencies:
+    "@babel/runtime" "^7.3.4"
+
 yargs-parser@^10.0.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
@@ -10894,7 +10901,7 @@ yargs@^12.0.1:
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
 
-yargs@^13.2.1:
+yargs@^13.2.1, yargs@^13.2.2:
   version "13.2.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.2.2.tgz#0c101f580ae95cea7f39d927e7770e3fdc97f993"
   integrity sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==


### PR DESCRIPTION
Requires base-cms/base-cms#29

- Adds website CLI tool to website monorepo
- Supports generating docker compose and travis deployment configuration when creating a site
- Passes configuration through to `basecms-website` CLI tool to create a site