### PR TITLE
Query home page sections using section alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "node_modules/.bin/lerna run test"
   },
   "devDependencies": {
-    "@base-cms/web-cli": "~0.6.8",
+    "@base-cms/web-cli": "~0.6.10",
     "lerna": "^3.13.1"
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -7,10 +7,10 @@
     "@base-cms/utils": "^0.6.0"
   },
   "peerDependencies": {
-    "@base-cms/marko-web": "~0.6.8"
+    "@base-cms/marko-web": "~0.6.10"
   },
   "devDependencies": {
-    "@base-cms/marko-web": "~0.6.8",
+    "@base-cms/marko-web": "~0.6.10",
     "eslint": "^5.15.1",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.16.0",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -6,10 +6,11 @@
     "bootstrap": "4.3.1"
   },
   "peerDependencies": {
-    "@base-cms/marko-web": "~0.6.8",
+    "@base-cms/marko-web": "~0.6.10",
     "@endeavorb2b/base-website-common": "^0.3.9"
   },
   "devDependencies": {
+    "@base-cms/marko-web": "~0.6.10",
     "@endeavorb2b/base-website-common": "^0.3.10",
     "stylelint": "^9.10.1",
     "stylelint-config-twbs-bootstrap": "^0.3.0"

--- a/sites/bioopticsworld/config/site.js
+++ b/sites/bioopticsworld/config/site.js
@@ -19,9 +19,9 @@ module.exports = {
     { href: '/about-us', label: 'About Us' },
   ],
   homeSections: [
-    { id: 30198, name: 'Bioscience' },
-    { id: 30201, name: 'Biomedicine' },
-    { id: 30203, name: 'Bioimaging' },
+    { alias: 'bioscience', name: 'Bioscience' },
+    { alias: 'biomedicine', name: 'Biomedicine' },
+    { alias: 'bioimaging', name: 'Bioimaging' },
   ],
   ads: {
     units: {

--- a/sites/bioopticsworld/package.json
+++ b/sites/bioopticsworld/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.6.8",
+    "@base-cms/marko-web": "~0.6.10",
     "@base-cms/object-path": "^0.6.0",
-    "@base-cms/web-cli": "~0.6.8",
+    "@base-cms/web-cli": "~0.6.10",
     "@endeavorb2b/base-website-common": "^0.3.10",
     "@endeavorb2b/base-website-themes": "^0.3.11",
     "bootstrap": "4.3.1",

--- a/sites/bioopticsworld/server/templates/index.marko
+++ b/sites/bioopticsworld/server/templates/index.marko
@@ -21,7 +21,7 @@ $ const sections = site.getAsArray('homeSections');
       <div class="row">
         <for|sectionItem| of=sections>
           <div class="col-lg-4 mb-5">
-            <endeavor-content-query-section-list section-id=sectionItem.id header=sectionItem.name />
+            <endeavor-content-query-section-list section-alias=sectionItem.alias header=sectionItem.name />
           </div>
         </for>
       </div>

--- a/sites/broadbandtechreport/config/site.js
+++ b/sites/broadbandtechreport/config/site.js
@@ -24,12 +24,12 @@ module.exports = {
     { href: '/page/about-us', label: 'About Us' },
   ],
   homeSections: [
-    { id: 30222, name: 'In the Network' },
-    { id: 30229, name: 'In the Home' },
-    { id: 30233, name: 'Mobile' },
-    { id: 30243, name: 'Internet' },
-    { id: 30244, name: 'Voice' },
-    { id: 30245, name: 'Business Services' },
+    { alias: 'in-the-network', name: 'In the Network' },
+    { alias: 'in-the-home', name: 'In the Home' },
+    { alias: 'mobile', name: 'Mobile' },
+    { alias: 'internet', name: 'Internet' },
+    { alias: 'voice', name: 'Voice' },
+    { alias: 'business-services', name: 'Business Services' },
   ],
   ad: {
     units: {

--- a/sites/broadbandtechreport/package.json
+++ b/sites/broadbandtechreport/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.6.8",
+    "@base-cms/marko-web": "~0.6.10",
     "@base-cms/object-path": "^0.6.0",
-    "@base-cms/web-cli": "~0.6.8",
+    "@base-cms/web-cli": "~0.6.10",
     "@endeavorb2b/base-website-common": "^0.3.10",
     "@endeavorb2b/base-website-themes": "^0.3.11",
     "graphql": "^14.1.1",

--- a/sites/broadbandtechreport/server/templates/index.marko
+++ b/sites/broadbandtechreport/server/templates/index.marko
@@ -1,4 +1,4 @@
-import { getAsObject, get } from '@base-cms/object-path';
+import { getAsObject } from '@base-cms/object-path';
 
 $ const section = getAsObject(data, 'section');
 $ const { site } = out.global;
@@ -21,7 +21,7 @@ $ const sections = site.getAsArray('homeSections');
       <div class="row">
         <for|sectionItem| of=sections>
           <div class="col-lg-4 mb-5">
-            <endeavor-content-query-section-list section-id=sectionItem.id header=sectionItem.name />
+            <endeavor-content-query-section-list section-alias=sectionItem.alias header=sectionItem.name />
           </div>
         </for>
       </div>

--- a/sites/dentaleconomics/config/site.js
+++ b/sites/dentaleconomics/config/site.js
@@ -21,9 +21,9 @@ module.exports = {
     { href: 'https://www.dentistryiq.com/products/free-samples', label: 'Free Samples' },
   ],
   homeSections: [
-    { id: 30016, label: 'Macro/Op-Ed' },
-    { id: 30017, label: 'Practice' },
-    { id: 30018, label: 'Science & Tech' },
+    { alias: 'macro-op-ed', label: 'Macro/Op-Ed' },
+    { alias: 'practice', label: 'Practice' },
+    { alias: 'science-tech', label: 'Science & Tech' },
   ],
   ads: {
     units: {

--- a/sites/dentaleconomics/package.json
+++ b/sites/dentaleconomics/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.6.8",
+    "@base-cms/marko-web": "~0.6.10",
     "@base-cms/object-path": "^0.6.0",
-    "@base-cms/web-cli": "~0.6.8",
+    "@base-cms/web-cli": "~0.6.10",
     "@endeavorb2b/base-website-common": "^0.3.10",
     "@endeavorb2b/base-website-themes": "^0.3.11",
     "bootstrap": "4.3.1",

--- a/sites/dentaleconomics/server/templates/index.marko
+++ b/sites/dentaleconomics/server/templates/index.marko
@@ -21,7 +21,7 @@ $ const sections = site.getAsArray('homeSections');
       <div class="row">
         <for|sectionItem| of=sections>
           <div class="col-lg-4 mb-5">
-            <endeavor-content-query-section-list section-id=sectionItem.id header=sectionItem.name />
+            <endeavor-content-query-section-list section-alias=sectionItem.alias header=sectionItem.name />
           </div>
         </for>
       </div>

--- a/sites/evaluationengineering/config/site.js
+++ b/sites/evaluationengineering/config/site.js
@@ -18,12 +18,12 @@ module.exports = {
     { href: '/page/about-us', label: 'About Us' },
   ],
   homeSections: [
-    { id: 60895, name: 'Applications' },
-    { id: 59814, name: 'Instrumentation' },
-    { id: 60924, name: 'Testing' },
-    { id: 60913, name: 'Industries' },
-    { id: 60955, name: 'Whitepapers' },
-    { id: 59826, name: 'Special Reports' },
+    { alias: 'applications', name: 'Applications' },
+    { alias: 'instrumentation', name: 'Instrumentation' },
+    { alias: 'testing', name: 'Testing' },
+    { alias: 'industries', name: 'Industries' },
+    { alias: 'whitepapers', name: 'Whitepapers' },
+    { alias: 'special-reports', name: 'Special Reports' },
   ],
   ad: {
     units: {

--- a/sites/evaluationengineering/package.json
+++ b/sites/evaluationengineering/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.6.8",
+    "@base-cms/marko-web": "~0.6.10",
     "@base-cms/object-path": "^0.6.0",
-    "@base-cms/web-cli": "~0.6.8",
+    "@base-cms/web-cli": "~0.6.10",
     "@endeavorb2b/base-website-common": "^0.3.10",
     "@endeavorb2b/base-website-themes": "^0.3.11",
     "bootstrap": "4.3.1",

--- a/sites/evaluationengineering/server/templates/index.marko
+++ b/sites/evaluationengineering/server/templates/index.marko
@@ -21,7 +21,7 @@ $ const sections = site.getAsArray('homeSections');
       <div class="row">
         <for|sectionItem| of=sections>
           <div class="col-lg-4 mb-5">
-            <endeavor-content-query-section-list section-id=sectionItem.id header=sectionItem.name />
+            <endeavor-content-query-section-list section-alias=sectionItem.alias header=sectionItem.name />
           </div>
         </for>
       </div>

--- a/sites/officer/config/site.js
+++ b/sites/officer/config/site.js
@@ -22,12 +22,12 @@ module.exports = {
     { href: '/contact-us', label: 'Contact Us' },
   ],
   homeSections: [
-    { id: 56179, name: 'Tactical' },
-    { id: 56208, name: 'Training & Careers' },
-    { id: 56221, name: 'On The Street' },
-    { id: 56341, name: 'Investigations' },
-    { id: 56374, name: 'Command/HQ' },
-    { id: 56401, name: 'Honoring the Fallen' },
+    { href: 'tactical', name: 'Tactical' },
+    { href: 'training-careers', name: 'Training & Careers' },
+    { href: 'on-the-street', name: 'On The Street' },
+    { href: 'investigations', name: 'Investigations' },
+    { href: 'command-hq', name: 'Command/HQ' },
+    { href: 'features/honoring-the-fallen', name: 'Honoring the Fallen' },
   ],
   ad: {
     units: {

--- a/sites/officer/package.json
+++ b/sites/officer/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.6.8",
+    "@base-cms/marko-web": "~0.6.10",
     "@base-cms/object-path": "^0.6.0",
-    "@base-cms/web-cli": "~0.6.8",
+    "@base-cms/web-cli": "~0.6.10",
     "@endeavorb2b/base-website-common": "^0.3.10",
     "@endeavorb2b/base-website-themes": "^0.3.11",
     "bootstrap": "4.3.1",

--- a/sites/officer/server/templates/index.marko
+++ b/sites/officer/server/templates/index.marko
@@ -21,13 +21,13 @@ $ const sections = site.getAsArray('homeSections');
       <div class="row">
         <for|sectionItem| of=sections>
           <div class="col-lg-4 mb-5">
-            <endeavor-content-query-section-list section-id=sectionItem.id header=sectionItem.name />
+            <endeavor-content-query-section-list section-alias=sectionItem.alias header=sectionItem.name />
           </div>
         </for>
       </div>
     </if>
 
-    <endeavor-gam-ad-unit alias="BS" modifiers=['home-page-inline'] />
+    <endeavor-gam-ad-unit alias="BS" modifiers=["home-page-inline"] />
     <endeavor-content-query-load-more
       skip=7
       section-id=section.id

--- a/sites/utilityproducts/config/site.js
+++ b/sites/utilityproducts/config/site.js
@@ -20,12 +20,12 @@ module.exports = {
     { href: '/events', label: 'Events' },
   ],
   homeSections: [
-    { id: 30003, name: 'Transmission & Distribution' },
-    { id: 30004, name: 'Vehicles & Accessories' },
-    { id: 30005, name: 'Tools & Supplies' },
-    { id: 30006, name: 'Safety' },
-    { id: 30007, name: 'Line Construction & Maintenance' },
-    { id: 30008, name: 'Test & Mesurement' },
+    { alias: 'transmission-distribution', name: 'Transmission & Distribution' },
+    { alias: 'vehicles-accessories', name: 'Vehicles & Accessories' },
+    { alias: 'tools-supplies', name: 'Tools & Supplies' },
+    { alias: 'safety', name: 'Safety' },
+    { alias: 'line-construction-maintenance', name: 'Line Construction & Maintenance' },
+    { alias: 'test-measurement', name: 'Test & Mesurement' },
   ],
   ad: {
     units: {

--- a/sites/utilityproducts/package.json
+++ b/sites/utilityproducts/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.6.8",
+    "@base-cms/marko-web": "~0.6.10",
     "@base-cms/object-path": "^0.6.0",
-    "@base-cms/web-cli": "~0.6.8",
+    "@base-cms/web-cli": "~0.6.10",
     "@endeavorb2b/base-website-common": "^0.3.10",
     "@endeavorb2b/base-website-themes": "^0.3.11",
     "graphql": "^14.1.1",

--- a/sites/utilityproducts/server/templates/index.marko
+++ b/sites/utilityproducts/server/templates/index.marko
@@ -1,4 +1,4 @@
-import { getAsObject, get } from '@base-cms/object-path';
+import { getAsObject } from '@base-cms/object-path';
 
 $ const section = getAsObject(data, 'section');
 $ const { site } = out.global;
@@ -21,7 +21,7 @@ $ const sections = site.getAsArray('homeSections');
       <div class="row">
         <for|sectionItem| of=sections>
           <div class="col-lg-4 mb-5">
-            <endeavor-content-query-section-list section-id=sectionItem.id header=sectionItem.name />
+            <endeavor-content-query-section-list section-alias=sectionItem.alias header=sectionItem.name />
           </div>
         </for>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -651,16 +651,16 @@
   dependencies:
     inflected "^2.0.4"
 
-"@base-cms/marko-web@^0.6.8", "@base-cms/marko-web@~0.6.8":
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/@base-cms/marko-web/-/marko-web-0.6.8.tgz#907c67a4927666e093c054bb35b93671ae5b5fc7"
-  integrity sha512-BI/9UsyLgTFKGDyVJ20M5S1leXSK4aYFVVT3OP15la1gtd6jzRDllv1v9op0dZGA225Dl+rO41m0nJOgaPBCtw==
+"@base-cms/marko-web@^0.6.10", "@base-cms/marko-web@~0.6.10":
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/@base-cms/marko-web/-/marko-web-0.6.10.tgz#6b8e221d2a2ea3e94792a08614212803c3edccae"
+  integrity sha512-wtKMSejSVpuYSPERfPTiU8/5/LG/UQRrxYToB7nrIRj7dG05bdTFvf7wFK6G4ozuqlZlWLZMVbC9GHpzyZ4+0g==
   dependencies:
     "@base-cms/express-apollo" "^0.6.0"
     "@base-cms/image" "^0.6.0"
     "@base-cms/object-path" "^0.6.0"
     "@base-cms/utils" "^0.6.0"
-    "@base-cms/web-common" "^0.6.8"
+    "@base-cms/web-common" "^0.6.10"
     "@godaddy/terminus" "^4.1.0"
     express "^4.16.4"
     http-errors "^1.7.2"
@@ -682,10 +682,10 @@
   resolved "https://registry.yarnpkg.com/@base-cms/utils/-/utils-0.6.0.tgz#4797b962576902223ffb1dc5fee7b24801cf9088"
   integrity sha512-bqBMnvhADjZ6pTNRuzX1pnISuHbdB0oG85It1a3MrG2SQ4DL/AWzdBpkbBgffr8Aspshk/a589BPNKnM2xTdhw==
 
-"@base-cms/web-cli@~0.6.8":
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/@base-cms/web-cli/-/web-cli-0.6.8.tgz#324f97eb87931a25b0c9cac608962fe960dad9b0"
-  integrity sha512-LmbW8aYZqJocFoelT2HfPUVMwzqYvv/xKTnz2oQ2jaWnabFokguQlGGf3PfT9ixxBJfxh+PU2LZ72K9vKIvMgA==
+"@base-cms/web-cli@~0.6.10":
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/@base-cms/web-cli/-/web-cli-0.6.10.tgz#52f0986e3d80698d235a32b49e42f94e03d9cff9"
+  integrity sha512-lF3PtoIH4x/+1BpzE4kg/6H3fEBGDUBMjICfTSRTEPTSa+NhA96aPVKWxKzhlc8zj+vKimisEEhU0SbFscxc9A==
   dependencies:
     "@babel/core" "^7.4.0"
     "@babel/plugin-transform-runtime" "^7.4.0"
@@ -693,7 +693,7 @@
     "@babel/runtime" "^7.4.2"
     "@babel/runtime-corejs2" "^7.4.2"
     "@base-cms/express-apollo" "^0.6.0"
-    "@base-cms/marko-web" "^0.6.8"
+    "@base-cms/marko-web" "^0.6.10"
     autoprefixer "^9.4.10"
     babel-loader "^8.0.5"
     chalk "^2.4.2"
@@ -737,10 +737,10 @@
     webpack-stream "^5.2.1"
     yargs "^13.2.1"
 
-"@base-cms/web-common@^0.6.8":
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/@base-cms/web-common/-/web-common-0.6.8.tgz#dd4b42942f4dc9b90b0e1f74af28631d19d6d1d9"
-  integrity sha512-1rFLFJ49emW+tNlsfnrkcXL79U/iTQXQ69V4+wj9xltFBRh3QqL8Dlf3GbwK/Dwss+3VEjctFJ1RKHtFKNy06Q==
+"@base-cms/web-common@^0.6.10":
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/@base-cms/web-common/-/web-common-0.6.10.tgz#c074330778371773f33efc6b79a7c4873c5b0e7c"
+  integrity sha512-+bQTWyLt5fSIMNR/kLSwZuHW9P79BO59VKYT248GEQijqNq9nyLZTjMk6BVfV5QdEZRBJ2XTI8ePQZwGr+cVEQ==
   dependencies:
     "@base-cms/inflector" "^0.6.0"
     "@base-cms/object-path" "^0.6.0"


### PR DESCRIPTION
The website `homeSections` config option was changed to use the section `alias` instead of the `id`. As such,  the `<endeavor-content-query-section-list>` call was changed to use the `section-alias` property.

All dependents of `@base-cms/web-cli` and `@base-cms/marko-web` were updated to use version `0.6.10` in order to access this new feature.