### PR TITLE
Various updates

### DIFF
--- a/packages/common/components/content/blocks/breadcrumbs.marko
+++ b/packages/common/components/content/blocks/breadcrumbs.marko
@@ -5,11 +5,13 @@ $ const primarySection = getAsObject(input.content, 'primarySection');
 
 <nav class=block aria-label="breadcrumb">
   <cms-website-section-hierarchy|{ section }| tag="ol" class="breadcrumb" block=block obj=primarySection>
-    <@before>
-      <li class="breadcrumb-item">
-        <a href="/" title="Home">Home</a>
-      </li>
-    </@before>
+    <if(primarySection.alias !== 'home')>
+      <@before>
+        <li class="breadcrumb-item">
+          <a href="/" title="Home">Home</a>
+        </li>
+      </@before>
+    </if>
     <cms-website-section-name tag="li" class="breadcrumb-item" block=block obj=section link=true />
   </cms-website-section-hierarchy>
 </nav>

--- a/packages/common/components/content/blocks/components/element-group-event.marko
+++ b/packages/common/components/content/blocks/components/element-group-event.marko
@@ -14,10 +14,8 @@ $ const company = getAsObject(input.content, 'company');
   <if(company.id)>
     <endeavor-content-company-name prefix="Sponsored By: " block=block company=company />
   </if>
-  <else>
-    <span class=`${block}__company` />
-  </else>
-  <span class=`${block}__dates`>
-    <endeavor-content-starts block=block obj=input.content /> &mdash; <endeavor-content-ends block=block obj=input.content />
+  <span class=`${block}__content-event-dates`>
+    <endeavor-content-starts block=block obj=input.content />
+    <endeavor-content-ends block=block obj=input.content />
   </span>
 </small>

--- a/packages/common/components/content/blocks/element-group.marko
+++ b/packages/common/components/content/blocks/element-group.marko
@@ -4,10 +4,6 @@ $ const block = 'content-element-group';
 $ const modifiers = Array.isArray(input.modifiers) ? input.modifiers.map(mod => `${block}--${mod}`) : [];
 $ const classNames = [block, ...modifiers, input.class];
 
-$ const primaryImage = getAsObject(input.content, 'primaryImage');
-$ const primarySection = getAsObject(input.content, 'primarySection');
-$ const company = getAsObject(input.content, 'company');
-
 <${input.tag} class=classNames>
   <if(input.content.type === 'webinar')>
     <element-group-webinar ...input />

--- a/packages/common/components/content/blocks/page-body.marko
+++ b/packages/common/components/content/blocks/page-body.marko
@@ -1,5 +1,18 @@
+$ const { site } = out.global;
 $ const block = 'content-page-body';
+$ const displayPrimaryImage = site.get('contentPage.displayPrimaryImage', true);
 
 <div class=block>
+  <if(displayPrimaryImage)>
+    <!-- @todo Add support for responsive images / size variance based on context -->
+    <div class=`${block}__primary-image`>
+      <endeavor-content-block-primary-image
+        content=input.content
+        lazyload=false
+        modifiers=['content-body']
+        options={ w: 756, h: 324, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
+      />
+    </div>
+  </if>
   <cms-content-body tag="div" block=block obj=input.content />
 </div>

--- a/packages/common/components/content/blocks/page-body.marko
+++ b/packages/common/components/content/blocks/page-body.marko
@@ -13,18 +13,21 @@ $ const displayMedia = displayPrimaryImage || content.embedCode;
   <if(displayMedia)>
     <div class=`${block}__primary-media`>
       <if(content.embedCode)>
-        <div class=`${block}__primary-embed-item`>
+        <div class=`${block}__primary-video`>
           $!{content.embedCode}
         </div>
       </if>
       <else-if(displayPrimaryImage)>
-        <!-- @todo Add support for responsive images / size variance based on context -->
-        <endeavor-content-block-primary-image
-          content=input.content
-          lazyload=false
-          modifiers=['content-body']
-          options={ w: 756, h: 324, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
-        />
+        <div class=`${block}__primary-image`>
+          <!-- @todo Add support for responsive images / size variance based on context -->
+          <cms-image-element
+            block=block
+            modifiers=['primary-image']
+            lazyload=false
+            obj=primaryImage
+            options={ w: 756, h: 324, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
+          />
+        </div>
       </else-if>
     </div>
   </if>

--- a/packages/common/components/content/blocks/page-body.marko
+++ b/packages/common/components/content/blocks/page-body.marko
@@ -2,27 +2,31 @@ import { getAsObject } from '@base-cms/object-path';
 
 $ const { site } = out.global;
 $ const block = 'content-page-body';
+
 $ const content = getAsObject(input, 'content');
-$ const displayPrimaryImage = site.get('contentPage.displayPrimaryImage', true);
+$ const primaryImage = getAsObject(content, 'primaryImage');
+
+$ const displayPrimaryImage = site.get('contentPage.displayPrimaryImage', true) && primaryImage.src;
+$ const displayMedia = displayPrimaryImage || content.embedCode;
 
 <div class=block>
-  <if(content.embedCode)>
-    <div class=`${block}__primary-embed`>
-      <div class=`${block}__primary-embed-item`>
-        $!{content.embedCode}
-      </div>
+  <if(displayMedia)>
+    <div class=`${block}__primary-media`>
+      <if(content.embedCode)>
+        <div class=`${block}__primary-embed-item`>
+          $!{content.embedCode}
+        </div>
+      </if>
+      <else-if(displayPrimaryImage)>
+        <!-- @todo Add support for responsive images / size variance based on context -->
+        <endeavor-content-block-primary-image
+          content=input.content
+          lazyload=false
+          modifiers=['content-body']
+          options={ w: 756, h: 324, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
+        />
+      </else-if>
     </div>
   </if>
-  <else-if(displayPrimaryImage)>
-    <!-- @todo Add support for responsive images / size variance based on context -->
-    <div class=`${block}__primary-image`>
-      <endeavor-content-block-primary-image
-        content=input.content
-        lazyload=false
-        modifiers=['content-body']
-        options={ w: 756, h: 324, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
-      />
-    </div>
-  </else-if>
   <cms-content-body tag="div" block=block obj=input.content />
 </div>

--- a/packages/common/components/content/blocks/page-body.marko
+++ b/packages/common/components/content/blocks/page-body.marko
@@ -1,9 +1,19 @@
+import { getAsObject } from '@base-cms/object-path';
+
 $ const { site } = out.global;
 $ const block = 'content-page-body';
+$ const content = getAsObject(input, 'content');
 $ const displayPrimaryImage = site.get('contentPage.displayPrimaryImage', true);
 
 <div class=block>
-  <if(displayPrimaryImage)>
+  <if(content.embedCode)>
+    <div class=`${block}__primary-embed`>
+      <div class=`${block}__primary-embed-item`>
+        $!{content.embedCode}
+      </div>
+    </div>
+  </if>
+  <else-if(displayPrimaryImage)>
     <!-- @todo Add support for responsive images / size variance based on context -->
     <div class=`${block}__primary-image`>
       <endeavor-content-block-primary-image
@@ -13,6 +23,6 @@ $ const displayPrimaryImage = site.get('contentPage.displayPrimaryImage', true);
         options={ w: 756, h: 324, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
       />
     </div>
-  </if>
+  </else-if>
   <cms-content-body tag="div" block=block obj=input.content />
 </div>

--- a/packages/common/components/content/blocks/page-header.marko
+++ b/packages/common/components/content/blocks/page-header.marko
@@ -1,9 +1,14 @@
+import { getAsObject } from '@base-cms/object-path';
+
 $ const block = 'content-page-header';
+$ const content = getAsObject(input, 'content');
 
 <div class=block>
   <endeavor-content-block-breadcrumbs content=input.content />
   <cms-content-name tag="h1" block=block obj=input.content />
   <cms-content-teaser tag="p" block=block obj=input.content />
-  <endeavor-content-block-attribution content=input.content />
-  <cms-content-published block=block obj=input.content />
+  <if(content.type !== 'contact')>
+    <endeavor-content-block-attribution content=input.content />
+    <cms-content-published block=block obj=input.content />
+  </if>
 </div>

--- a/packages/common/components/content/blocks/page-title.marko
+++ b/packages/common/components/content/blocks/page-title.marko
@@ -4,9 +4,9 @@ $ const block = 'content-page-title';
 
 <div class=`${block} card`>
   <if(input.header)>
-    <h2 class=`${block}__header card-header`>
+    <h1 class=`${block}__header card-header`>
       ${input.header}
-    </h2>
+    </h1>
   </if>
   <div class=`${block}__body card-body`>
     ${input.body} &nbsp;

--- a/packages/common/utils/published-content/index.js
+++ b/packages/common/utils/published-content/index.js
@@ -1,0 +1,3 @@
+const pageDetails = require('./page-details');
+
+module.exports = { pageDetails };

--- a/packages/common/utils/published-content/page-details.js
+++ b/packages/common/utils/published-content/page-details.js
@@ -1,0 +1,4 @@
+module.exports = (title, config) => ({
+  title,
+  description: `The latest ${(title || '').toLowerCase()} from ${config.siteName()}`,
+});

--- a/packages/themes/pennwell/components/layouts/published-content.marko
+++ b/packages/themes/pennwell/components/layouts/published-content.marko
@@ -1,7 +1,11 @@
 import { getAsObject } from '@base-cms/object-path';
 
+$ const page = getAsObject(input, 'page');
+
 <theme-pennwell-document>
   <@head>
+    <cms-page-title value=page.title />
+    <cms-page-description content=page.description />
     <${input.head} />
   </@head>
   <div class="container-fluid-max">

--- a/packages/themes/pennwell/styles/bootstrap/_mixins.scss
+++ b/packages/themes/pennwell/styles/bootstrap/_mixins.scss
@@ -90,13 +90,9 @@
 }
 
 @mixin theme-content-body-paragraph() {
-  margin-top: 29px;
-  margin-bottom: 0;
+  margin-bottom: 29px;
   @include media-breakpoint-down(sm) {
-    margin-top: 21px;
-  }
-  &:first-child {
-    margin-top: 0;
+    margin-bottom: 21px;
   }
   &:empty {
     display: none;
@@ -111,16 +107,6 @@
   @include media-breakpoint-down(sm) {
     font-size: 17px;
     line-height: 27px;
-  }
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    &:first-child {
-      margin-top: 0;
-    }
   }
   h1 {
     @include content-body-heading(h1);
@@ -144,20 +130,17 @@
   b {
     font-weight: 700;
   }
-  img {
-    margin-bottom: map-get($spacers, 1);
+  [data-embed-type="image"] img {
     border-radius: $border-radius;
-    box-shadow: $theme-box-shadow-sm;
+    box-shadow: $theme-box-shadow-lg;
   }
   p,
   ul,
   table,
   [data-oembed-type="video"],
+  [data-embed-type="image"],
   ol {
     @include theme-content-body-paragraph();
-  }
-  &:first-child {
-    margin-top: 0;
   }
 }
 
@@ -166,31 +149,31 @@
   $large-margin-sm: 48px;
   @include theme-heading($size);
   @if $size == h1 {
-    margin-top: $large-margin;
+    margin-bottom: $large-margin;
     @include media-breakpoint-down(sm) {
-      margin-top: $large-margin-sm;
+      margin-bottom: $large-margin-sm;
     }
   } @else if $size == h2 {
-    margin-top: $large-margin;
+    margin-bottom: $large-margin;
     @include media-breakpoint-down(sm) {
-      margin-top: $large-margin-sm;
+      margin-bottom: $large-margin-sm;
     }
   } @else if $size == h3 {
-    margin-top: $large-margin;
+    margin-bottom: $large-margin;
     @include media-breakpoint-down(sm) {
-      margin-top: $large-margin-sm;
+      margin-bottom: $large-margin-sm;
     }
   } @else if $size == h4 {
-    margin-top: 39px;
+    margin-bottom: 39px;
     @include media-breakpoint-down(sm) {
-      margin-top: 31px;
+      margin-bottom: 31px;
     }
   } @else if $size == h5 {
-    margin-top: 25px;
+    margin-bottom: 25px;
     @include media-breakpoint-down(sm) {
-      margin-top: 17px;
+      margin-bottom: 17px;
     }
   } @else {
-    margin-top: 11px;
+    margin-bottom: 11px;
   }
 }

--- a/packages/themes/pennwell/styles/components/_site-footer.scss
+++ b/packages/themes/pennwell/styles/components/_site-footer.scss
@@ -1,5 +1,8 @@
 .site-footer {
   $drop-shadow: 2px 2px 2px rgba(0, 0, 0, .5);
+  $spacer-lg: map-get($spacers, 3);
+  $spacer-sm: map-get($spacers, 2);
+
   @extend .navbar-dark;
   margin-top: auto;
   font-family: $theme-content-sans-serif-font;
@@ -8,9 +11,14 @@
 
   &__container {
     @include make-container();
-    padding-top: map-get($spacers, 3);
-    padding-bottom: map-get($spacers, 3);
+    padding-top: $spacer-lg;
+    padding-bottom: $spacer-lg;
     text-align: center;
+
+    @include media-breakpoint-down(sm) {
+      padding-top: $spacer-sm;
+      padding-bottom: $spacer-sm;
+    }
 
     &--brand {
       background-color: $theme-site-footer-primary-bg-color;
@@ -26,6 +34,9 @@
     img {
       height: 50px;
       filter: brightness(0) invert(1) drop-shadow($drop-shadow);
+      @include media-breakpoint-down(sm) {
+        height: 30px;
+      }
     }
   }
 
@@ -33,17 +44,27 @@
     display: flex;
     flex-direction: row;
     justify-content: center;
-    margin-bottom: map-get($spacers, 3);
+    margin-bottom: $spacer-lg;
+    @include media-breakpoint-down(sm) {
+      margin-bottom: $spacer-sm;
+    }
   }
 
   &__social-icon {
-    margin: 0 map-get($spacers, 3);
+    margin: 0 $spacer-lg;
+    @include media-breakpoint-down(sm) {
+      margin: 0 $spacer-sm;
+    }
     svg {
       width: 40px;
       filter: drop-shadow($drop-shadow);
       border-radius: $border-radius;
       transition: fill ease 250ms, background-color ease 250ms;
       fill: $white;
+      @include media-breakpoint-down(sm) {
+        width: 25px;
+        margin: 0 $spacer-sm;
+      }
     }
     &--facebook {
       &:hover svg {
@@ -68,11 +89,18 @@
     display: flex;
     flex-direction: row;
     justify-content: center;
-    margin-bottom: map-get($spacers, 3);
+    margin-bottom: $spacer-lg;
+    @include media-breakpoint-down(sm) {
+      margin-bottom: $spacer-sm;
+      font-size: $font-size-sm;
+    }
   }
 
   &__link {
-    margin: 0 map-get($spacers, 3);
+    margin: 0 $spacer-lg;
+    @include media-breakpoint-down(sm) {
+      margin: 0 $spacer-sm;
+    }
     a {
       padding: 0;
     }

--- a/packages/themes/pennwell/styles/components/content/_card.scss
+++ b/packages/themes/pennwell/styles/components/content/_card.scss
@@ -1,5 +1,6 @@
 .content-card {
   @include theme-card();
+  min-height: 100%;
   .card-body {
     @include theme-item();
   }

--- a/packages/themes/pennwell/styles/components/content/_element-group.scss
+++ b/packages/themes/pennwell/styles/components/content/_element-group.scss
@@ -55,12 +55,17 @@
     }
   }
   &__content-published,
-  &__content-starts,
-  &__content-ends {
+  &__content-event-dates {
     @include theme-list-text();
     margin-top: auto;
     color: $gray;
-
+  }
+  &__content-ends {
+    &::before {
+      margin-right: map-get($spacers, 1);
+      margin-left: map-get($spacers, 1);
+      content: "\2014";
+    }
   }
   &__content-name {
     &--company-name {

--- a/packages/themes/pennwell/styles/components/content/_page-body.scss
+++ b/packages/themes/pennwell/styles/components/content/_page-body.scss
@@ -1,7 +1,6 @@
 .content-page-body {
   &__content-body,
-  &__primary-image,
-  &__primary-embed {
+  &__primary-media {
     @include content-body();
     padding-right: map-get($spacers, 3);
     padding-left: map-get($spacers, 3);

--- a/packages/themes/pennwell/styles/components/content/_page-body.scss
+++ b/packages/themes/pennwell/styles/components/content/_page-body.scss
@@ -1,5 +1,6 @@
 .content-page-body {
-  &__content-body {
+  &__content-body,
+  &__primary-image {
     @include content-body();
     padding-right: map-get($spacers, 3);
     padding-left: map-get($spacers, 3);

--- a/packages/themes/pennwell/styles/components/content/_page-body.scss
+++ b/packages/themes/pennwell/styles/components/content/_page-body.scss
@@ -29,8 +29,19 @@
     }
   }
 
-  &__primary-embed-item {
+  &__primary-video {
     @extend .embed-responsive;
     @extend .embed-responsive-16by9;
+  }
+
+  &__primary-image {
+    @extend .embed-responsive;
+    @extend .embed-responsive-21by9;
+    border-radius: $border-radius;
+    box-shadow: $theme-box-shadow-lg;
+    img {
+      @extend .embed-responsive-item;
+      border-radius: $border-radius;
+    }
   }
 }

--- a/packages/themes/pennwell/styles/components/content/_page-body.scss
+++ b/packages/themes/pennwell/styles/components/content/_page-body.scss
@@ -1,6 +1,7 @@
 .content-page-body {
   &__content-body,
-  &__primary-image {
+  &__primary-image,
+  &__primary-embed {
     @include content-body();
     padding-right: map-get($spacers, 3);
     padding-left: map-get($spacers, 3);
@@ -27,5 +28,10 @@
         content: "Credit \2014";
       }
     }
+  }
+
+  &__primary-embed-item {
+    @extend .embed-responsive;
+    @extend .embed-responsive-16by9;
   }
 }

--- a/packages/themes/pennwell/styles/components/content/_page-title.scss
+++ b/packages/themes/pennwell/styles/components/content/_page-title.scss
@@ -4,7 +4,7 @@
 
   &__header {
     @include theme-card-header();
-    @include theme-heading(h2);
+    @include theme-heading(h6);
   }
 
   .card-body {

--- a/packages/themes/pennwell/styles/components/content/_primary-image.scss
+++ b/packages/themes/pennwell/styles/components/content/_primary-image.scss
@@ -58,4 +58,22 @@
       }
     }
   }
+  &--content-body {
+    #{ $self } {
+      &__content-link {
+        @extend .embed-responsive;
+        @extend .embed-responsive-21by9;
+        width: auto;
+      }
+      &__asset-image {
+        @extend .embed-responsive-item;
+        max-width: 100%;
+        height: auto;
+        border-radius: $border-radius;
+      }
+      &__placeholder {
+        display: none;
+      }
+    }
+  }
 }

--- a/packages/themes/pennwell/styles/components/content/_primary-image.scss
+++ b/packages/themes/pennwell/styles/components/content/_primary-image.scss
@@ -1,11 +1,28 @@
 .content-primary-image {
   $self: &;
+  $drop-shadow: 2px 2px 2px rgba(0, 0, 0, .5);
   &__content-link {
+    position: relative;
     display: block;
     border-radius: $border-radius;
     box-shadow: $theme-box-shadow-lg;
     &--placeholder {
       background-color: $primary;
+    }
+    &--video {
+      &::after {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: 50px;
+        height: 50px;
+        content: "";
+        background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAZ8SURBVHhe7Z1Z6O1TFMf/hswhY+Yx3UiR8UF4IUIoD3QfyAPu7UYpDzLHgweRB8mUPJgyS3mQTGVKxohkypTpIkNmvp/cX3Fb53/273f2Xnvv39nf+jzc4ezfsM7Za+291157oampqampacTaXhwpVojrxGPiDfG+WCl+E3+LP1f9+SPxlnha3CTOE8eJPcQaoqmnthFLxS2Cl87LjsUX4m5xpsBATRO0meAX8KywXmQq3hYXiR1Fk0RXdL/4RVgvzIu/xFOCX+baYq5EP368eEFYLyc3dJNniHXF6IVzfV1YL6I0PhHLxZpidNpJPCSsBy+dl8QBYhSiPz5f/CSsh60FQurrxaaiWhG5MBawHrBW8C/7i+p0jPhaWA9VO0SE54gqBpnc5OWCMNJ6mDFxr1hfFKu1xM3Cuvmx8owo0q/wTak1ipqV1wTTPcVoA/G4sG52XvhAMAmaXXRT8/rLWB0GvJuLbMKBz5vPmMbzgh4ji64Q1k3NO/QY9ByuYpwxD6HtUC4UbtpBjHXQF4s/xGEiuZibIva2bqLxfz4VW4mkYqLQunjD5h6RTEyh1z5rm4OjRRK18cYw3hXriag6VlgXi83vxt+NgUtFNDEA9Fp2vUOcIsitsv69Vn4Q0UbxJCRYF0nB7QIxWXmx+FlY/69GLhNR9KKwLpCCziCdWHXkVzOGQei3YhMxk44QVuOpWN0gnQ4WzwnrMzXBsGEm3SeshlMxySAIX3aq+ExYn62BD8XgpV/SO38VVsOpWMwgnTYSTGzW6l8GT6mQJGY1mJIQg3Tq/IvVTsmQRD5IOfrsPgbpdLh4WVjtlcj3oveaybbCaiw1QwyCSPc8XdTiX0ip7SWywK2GUjPUIJ3wL1cKb9/Xl6tFL+VammVrQgztLmjLukYJvCp6iSwKq6HUPCJiqlT/Qq7wFiJIpLNYjXgQ2yAI/7JMfCWsa+biBBEkdjVZDXiQwiCdyDC8SpTiX4JH7ez1sxrwIKVBOuFfHhTW9T25TQSJrcdWAx54GKTTUeJNYd2HB2xwDRL7wK0GPPA0CCJpgxmJHP6F2d8g5dwD6G2QTviXa4X3imXQxtKcq3W5DNJpT/GosO4tBUGh7zfC+rAHuQ3Sycu/7CKmKmdYWIpBEP7lXEFfb91rDPYWi4pBlPVBL0oySKedxefCut9ZOURMFXmp1oc9KMkgrOylzoDZV0zVd8L6sAelGIQXRe0T6x5jwiB1quY5yiLqoUAAk3/W/cVmazFVOUevuQyCA2fKKKUDtwhaOcy53YDKD95iij7Hl5DE9SBRFs9qwAO+DF4iSSLnItYrIkjUKLQa8MDDIKSpUm0idxrRnSJIXpnuFqkNcrIoJZE7ONeX4pBWAx6kMghh7BPCumYu+HIEiQHRl8JqJDWxDUIYy/pOiftOmAEIFqVUrUZSE8sg3TpHzonSxXhP9BJ1ba2GUhPDIISxpdd1vFH0Ui4/MotBCGPZ9Wq1WxrB/uO/ekdYjaVkiEEIYy8RtWTDs7wxaHvbBcJqMCV9DXKSqG0/4gNikNiX7r2VLNQgLOyUFsaGcqIYrCeF1WgqphmETUSlhrEhEPWtIwbLOwt+kkFypuvE5Boxk3gRxMxW4ymwDFLbhpxJ4MyjlAH0HJOwa6sTYSwTcNb/q5HeY49Jos+jML11kdgwoCOMpQDYmIoG4PN2E9F0lrAuFBt8RG1hbAisMUUVNQQ5JcC6WGNxqL63pYgujmzwWvwfExwOk0xkZFgXbdhQNjbpgTAUT4l9ctpYIYmB5O3k4vyM0rcdl8Bpwk1nC+smGv8SvF0tlljm9a4UVAuMpTYU7iLrziP/tSY+FllPScDJl75c6gWJIS5OfJr4Rsx75PWjOEgUI+rB50zSzgkj8aKM0YnFI+/DhXNDyb4loljh6B8W1s2PDc50304UL6YKOBI759a41NwqqM1VlVjp81pH8YLpENcReGwx7cwBjNbD1QYThXuJUYiN+JwSYD1o6ZApwhR60lnbHGJpllMCKExvPXhpsOxKqcPgym+1ijRKdjCtFNaLyA0z2TeIqGvgNWhjQVW1UtbQ6ZrImyrixM6com8+VBBKehct4NdAdTnqHwaVSpo34WfY48g3lVKqKXKLSfwjR4qyGcwuNPUQDpXkZLo2fkGEnqG+hzEDGY93CTZYYgASyJsSiO6F4GBXsY84UOy36s+cHZjtPNqmpqampqY8Wlj4B3teNzXdJUMzAAAAAElFTkSuQmCC");
+        filter: brightness(0) invert(1) drop-shadow($drop-shadow);
+        background-size: contain;
+        opacity: .6;
+        transform: translate(-50%, -50%);
+      }
     }
   }
   &__asset-image {

--- a/packages/themes/pennwell/styles/components/content/_primary-image.scss
+++ b/packages/themes/pennwell/styles/components/content/_primary-image.scss
@@ -75,19 +75,4 @@
       }
     }
   }
-  &--content-body {
-    #{ $self } {
-      &__content-link {
-        @extend .embed-responsive;
-        @extend .embed-responsive-21by9;
-        width: auto;
-      }
-      &__asset-image {
-        @extend .embed-responsive-item;
-        max-width: 100%;
-        height: auto;
-        border-radius: $border-radius;
-      }
-    }
-  }
 }

--- a/packages/themes/pennwell/styles/components/content/_primary-image.scss
+++ b/packages/themes/pennwell/styles/components/content/_primary-image.scss
@@ -88,9 +88,6 @@
         height: auto;
         border-radius: $border-radius;
       }
-      &__placeholder {
-        display: none;
-      }
     }
   }
 }

--- a/sites/bioopticsworld/config/site.js
+++ b/sites/bioopticsworld/config/site.js
@@ -38,7 +38,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/bioopticsworld/server/routes/published-content.js
+++ b/sites/bioopticsworld/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/bioopticsworld/server/templates/published-content/events.marko
+++ b/sites/bioopticsworld/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/bioopticsworld/server/templates/published-content/videos.marko
+++ b/sites/bioopticsworld/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/bioopticsworld/server/templates/published-content/webinars.marko
+++ b/sites/bioopticsworld/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/bioopticsworld/server/templates/published-content/webinars.marko
+++ b/sites/bioopticsworld/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/bioopticsworld/server/templates/published-content/white-papers.marko
+++ b/sites/bioopticsworld/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/broadbandtechreport/config/site.js
+++ b/sites/broadbandtechreport/config/site.js
@@ -43,7 +43,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/broadbandtechreport/server/routes/published-content.js
+++ b/sites/broadbandtechreport/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/broadbandtechreport/server/templates/published-content/events.marko
+++ b/sites/broadbandtechreport/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/broadbandtechreport/server/templates/published-content/videos.marko
+++ b/sites/broadbandtechreport/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/broadbandtechreport/server/templates/published-content/webinars.marko
+++ b/sites/broadbandtechreport/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/broadbandtechreport/server/templates/published-content/webinars.marko
+++ b/sites/broadbandtechreport/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/broadbandtechreport/server/templates/published-content/white-papers.marko
+++ b/sites/broadbandtechreport/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/cablinginstall/config/site.js
+++ b/sites/cablinginstall/config/site.js
@@ -41,7 +41,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/cablinginstall/server/routes/published-content.js
+++ b/sites/cablinginstall/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/cablinginstall/server/templates/published-content/events.marko
+++ b/sites/cablinginstall/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/cablinginstall/server/templates/published-content/videos.marko
+++ b/sites/cablinginstall/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/cablinginstall/server/templates/published-content/webinars.marko
+++ b/sites/cablinginstall/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/cablinginstall/server/templates/published-content/webinars.marko
+++ b/sites/cablinginstall/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/cablinginstall/server/templates/published-content/white-papers.marko
+++ b/sites/cablinginstall/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/dentaleconomics/config/site.js
+++ b/sites/dentaleconomics/config/site.js
@@ -40,7 +40,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/dentaleconomics/server/routes/published-content.js
+++ b/sites/dentaleconomics/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/dentaleconomics/server/templates/published-content/events.marko
+++ b/sites/dentaleconomics/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/dentaleconomics/server/templates/published-content/videos.marko
+++ b/sites/dentaleconomics/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/dentaleconomics/server/templates/published-content/webinars.marko
+++ b/sites/dentaleconomics/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/dentaleconomics/server/templates/published-content/webinars.marko
+++ b/sites/dentaleconomics/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/dentaleconomics/server/templates/published-content/white-papers.marko
+++ b/sites/dentaleconomics/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/dentistryiq/config/site.js
+++ b/sites/dentistryiq/config/site.js
@@ -41,7 +41,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/dentistryiq/server/routes/published-content.js
+++ b/sites/dentistryiq/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/dentistryiq/server/templates/published-content/events.marko
+++ b/sites/dentistryiq/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/dentistryiq/server/templates/published-content/videos.marko
+++ b/sites/dentistryiq/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/dentistryiq/server/templates/published-content/webinars.marko
+++ b/sites/dentistryiq/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/dentistryiq/server/templates/published-content/webinars.marko
+++ b/sites/dentistryiq/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/dentistryiq/server/templates/published-content/white-papers.marko
+++ b/sites/dentistryiq/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/evaluationengineering/config/site.js
+++ b/sites/evaluationengineering/config/site.js
@@ -37,7 +37,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/evaluationengineering/server/routes/published-content.js
+++ b/sites/evaluationengineering/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/evaluationengineering/server/templates/index.marko
+++ b/sites/evaluationengineering/server/templates/index.marko
@@ -34,7 +34,7 @@ $ const adSlots = {
     </div>
   </if>
 
-  <endeavor-gam-ad-unit-display id="gpt-ad-lb2" modifiers=["home-page-inline"] />
+  <endeavor-gam-ad-unit-display id="gpt-ad-lb2" modifiers=["inline"] />
 
   <@below-container>
     <endeavor-content-query-load-more

--- a/sites/evaluationengineering/server/templates/published-content/events.marko
+++ b/sites/evaluationengineering/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/evaluationengineering/server/templates/published-content/videos.marko
+++ b/sites/evaluationengineering/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
 $ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'BS' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'MR' }),
-};
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/evaluationengineering/server/templates/published-content/webinars.marko
+++ b/sites/evaluationengineering/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/evaluationengineering/server/templates/published-content/webinars.marko
+++ b/sites/evaluationengineering/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/evaluationengineering/server/templates/published-content/white-papers.marko
+++ b/sites/evaluationengineering/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/industrial-lasers/config/site.js
+++ b/sites/industrial-lasers/config/site.js
@@ -41,7 +41,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/industrial-lasers/server/routes/published-content.js
+++ b/sites/industrial-lasers/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/industrial-lasers/server/templates/published-content/events.marko
+++ b/sites/industrial-lasers/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/industrial-lasers/server/templates/published-content/videos.marko
+++ b/sites/industrial-lasers/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/industrial-lasers/server/templates/published-content/webinars.marko
+++ b/sites/industrial-lasers/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/industrial-lasers/server/templates/published-content/webinars.marko
+++ b/sites/industrial-lasers/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/industrial-lasers/server/templates/published-content/white-papers.marko
+++ b/sites/industrial-lasers/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/intelligent-aerospace/config/site.js
+++ b/sites/intelligent-aerospace/config/site.js
@@ -40,7 +40,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/intelligent-aerospace/server/routes/published-content.js
+++ b/sites/intelligent-aerospace/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/intelligent-aerospace/server/templates/published-content/events.marko
+++ b/sites/intelligent-aerospace/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/intelligent-aerospace/server/templates/published-content/videos.marko
+++ b/sites/intelligent-aerospace/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/intelligent-aerospace/server/templates/published-content/webinars.marko
+++ b/sites/intelligent-aerospace/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/intelligent-aerospace/server/templates/published-content/webinars.marko
+++ b/sites/intelligent-aerospace/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/intelligent-aerospace/server/templates/published-content/white-papers.marko
+++ b/sites/intelligent-aerospace/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/laserfocusworld/config/site.js
+++ b/sites/laserfocusworld/config/site.js
@@ -39,7 +39,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/laserfocusworld/server/routes/published-content.js
+++ b/sites/laserfocusworld/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/laserfocusworld/server/templates/published-content/events.marko
+++ b/sites/laserfocusworld/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/laserfocusworld/server/templates/published-content/videos.marko
+++ b/sites/laserfocusworld/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/laserfocusworld/server/templates/published-content/webinars.marko
+++ b/sites/laserfocusworld/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/laserfocusworld/server/templates/published-content/webinars.marko
+++ b/sites/laserfocusworld/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/laserfocusworld/server/templates/published-content/white-papers.marko
+++ b/sites/laserfocusworld/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/ledsmagazine/config/site.js
+++ b/sites/ledsmagazine/config/site.js
@@ -39,7 +39,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/ledsmagazine/server/routes/published-content.js
+++ b/sites/ledsmagazine/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/ledsmagazine/server/templates/published-content/events.marko
+++ b/sites/ledsmagazine/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/ledsmagazine/server/templates/published-content/videos.marko
+++ b/sites/ledsmagazine/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/ledsmagazine/server/templates/published-content/webinars.marko
+++ b/sites/ledsmagazine/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/ledsmagazine/server/templates/published-content/webinars.marko
+++ b/sites/ledsmagazine/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/ledsmagazine/server/templates/published-content/white-papers.marko
+++ b/sites/ledsmagazine/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/lightwaveonline/config/site.js
+++ b/sites/lightwaveonline/config/site.js
@@ -41,7 +41,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/lightwaveonline/server/routes/published-content.js
+++ b/sites/lightwaveonline/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/lightwaveonline/server/templates/published-content/events.marko
+++ b/sites/lightwaveonline/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/lightwaveonline/server/templates/published-content/videos.marko
+++ b/sites/lightwaveonline/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/lightwaveonline/server/templates/published-content/webinars.marko
+++ b/sites/lightwaveonline/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/lightwaveonline/server/templates/published-content/webinars.marko
+++ b/sites/lightwaveonline/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/lightwaveonline/server/templates/published-content/white-papers.marko
+++ b/sites/lightwaveonline/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/militaryaerospace/config/site.js
+++ b/sites/militaryaerospace/config/site.js
@@ -41,7 +41,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/militaryaerospace/server/routes/published-content.js
+++ b/sites/militaryaerospace/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/militaryaerospace/server/templates/published-content/events.marko
+++ b/sites/militaryaerospace/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/militaryaerospace/server/templates/published-content/videos.marko
+++ b/sites/militaryaerospace/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/militaryaerospace/server/templates/published-content/webinars.marko
+++ b/sites/militaryaerospace/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/militaryaerospace/server/templates/published-content/webinars.marko
+++ b/sites/militaryaerospace/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/militaryaerospace/server/templates/published-content/white-papers.marko
+++ b/sites/militaryaerospace/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/officer/config/site.js
+++ b/sites/officer/config/site.js
@@ -41,7 +41,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/officer/server/routes/published-content.js
+++ b/sites/officer/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/officer/server/templates/index.marko
+++ b/sites/officer/server/templates/index.marko
@@ -34,7 +34,7 @@ $ const adSlots = {
     </div>
   </if>
 
-  <endeavor-gam-ad-unit-display id="gpt-ad-lb2" modifiers=["home-page-inline"] />
+  <endeavor-gam-ad-unit-display id="gpt-ad-lb2" modifiers=["inline"] />
 
   <@below-container>
     <endeavor-content-query-load-more

--- a/sites/officer/server/templates/published-content/events.marko
+++ b/sites/officer/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/officer/server/templates/published-content/videos.marko
+++ b/sites/officer/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
 $ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'BS' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'MR' }),
-};
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/officer/server/templates/published-content/webinars.marko
+++ b/sites/officer/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/officer/server/templates/published-content/webinars.marko
+++ b/sites/officer/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/officer/server/templates/published-content/white-papers.marko
+++ b/sites/officer/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/offshore-mag/config/site.js
+++ b/sites/offshore-mag/config/site.js
@@ -43,7 +43,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/offshore-mag/server/routes/published-content.js
+++ b/sites/offshore-mag/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/offshore-mag/server/templates/published-content/events.marko
+++ b/sites/offshore-mag/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/offshore-mag/server/templates/published-content/videos.marko
+++ b/sites/offshore-mag/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/offshore-mag/server/templates/published-content/webinars.marko
+++ b/sites/offshore-mag/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/offshore-mag/server/templates/published-content/webinars.marko
+++ b/sites/offshore-mag/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/offshore-mag/server/templates/published-content/white-papers.marko
+++ b/sites/offshore-mag/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/ogj/config/site.js
+++ b/sites/ogj/config/site.js
@@ -38,7 +38,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/ogj/server/routes/published-content.js
+++ b/sites/ogj/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/ogj/server/templates/published-content/events.marko
+++ b/sites/ogj/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/ogj/server/templates/published-content/videos.marko
+++ b/sites/ogj/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/ogj/server/templates/published-content/webinars.marko
+++ b/sites/ogj/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/ogj/server/templates/published-content/webinars.marko
+++ b/sites/ogj/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/ogj/server/templates/published-content/white-papers.marko
+++ b/sites/ogj/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/perioimplantadvisory/config/site.js
+++ b/sites/perioimplantadvisory/config/site.js
@@ -41,7 +41,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/perioimplantadvisory/server/routes/published-content.js
+++ b/sites/perioimplantadvisory/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/perioimplantadvisory/server/templates/published-content/events.marko
+++ b/sites/perioimplantadvisory/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/perioimplantadvisory/server/templates/published-content/videos.marko
+++ b/sites/perioimplantadvisory/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/perioimplantadvisory/server/templates/published-content/webinars.marko
+++ b/sites/perioimplantadvisory/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/perioimplantadvisory/server/templates/published-content/webinars.marko
+++ b/sites/perioimplantadvisory/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/perioimplantadvisory/server/templates/published-content/white-papers.marko
+++ b/sites/perioimplantadvisory/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/plasticsmachinerymagazine/config/site.js
+++ b/sites/plasticsmachinerymagazine/config/site.js
@@ -41,7 +41,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/plasticsmachinerymagazine/server/routes/published-content.js
+++ b/sites/plasticsmachinerymagazine/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/plasticsmachinerymagazine/server/templates/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/index.marko
@@ -34,7 +34,7 @@ $ const adSlots = {
     </div>
   </if>
 
-  <endeavor-gam-ad-unit-display id="gpt-ad-lb2" modifiers=["home-page-inline"] />
+  <endeavor-gam-ad-unit-display id="gpt-ad-lb2" modifiers=["inline"] />
 
   <@below-container>
     <endeavor-content-query-load-more

--- a/sites/plasticsmachinerymagazine/server/templates/published-content/events.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/plasticsmachinerymagazine/server/templates/published-content/videos.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
 $ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'BS' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'MR' }),
-};
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/plasticsmachinerymagazine/server/templates/published-content/webinars.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/plasticsmachinerymagazine/server/templates/published-content/webinars.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/plasticsmachinerymagazine/server/templates/published-content/white-papers.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/rdhmag/config/site.js
+++ b/sites/rdhmag/config/site.js
@@ -38,7 +38,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/rdhmag/server/routes/published-content.js
+++ b/sites/rdhmag/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/rdhmag/server/templates/published-content/events.marko
+++ b/sites/rdhmag/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/rdhmag/server/templates/published-content/videos.marko
+++ b/sites/rdhmag/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/rdhmag/server/templates/published-content/webinars.marko
+++ b/sites/rdhmag/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/rdhmag/server/templates/published-content/webinars.marko
+++ b/sites/rdhmag/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/rdhmag/server/templates/published-content/white-papers.marko
+++ b/sites/rdhmag/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/strategies-u/config/site.js
+++ b/sites/strategies-u/config/site.js
@@ -27,7 +27,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/strategies-u/server/routes/published-content.js
+++ b/sites/strategies-u/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/strategies-u/server/templates/published-content/events.marko
+++ b/sites/strategies-u/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/strategies-u/server/templates/published-content/videos.marko
+++ b/sites/strategies-u/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/strategies-u/server/templates/published-content/webinars.marko
+++ b/sites/strategies-u/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/strategies-u/server/templates/published-content/webinars.marko
+++ b/sites/strategies-u/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/strategies-u/server/templates/published-content/white-papers.marko
+++ b/sites/strategies-u/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/utilityproducts/config/site.js
+++ b/sites/utilityproducts/config/site.js
@@ -39,7 +39,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/utilityproducts/server/routes/published-content.js
+++ b/sites/utilityproducts/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/utilityproducts/server/templates/published-content/events.marko
+++ b/sites/utilityproducts/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/utilityproducts/server/templates/published-content/videos.marko
+++ b/sites/utilityproducts/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/utilityproducts/server/templates/published-content/webinars.marko
+++ b/sites/utilityproducts/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/utilityproducts/server/templates/published-content/webinars.marko
+++ b/sites/utilityproducts/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/utilityproducts/server/templates/published-content/white-papers.marko
+++ b/sites/utilityproducts/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/vision-systems/config/site.js
+++ b/sites/vision-systems/config/site.js
@@ -40,7 +40,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/vision-systems/server/routes/published-content.js
+++ b/sites/vision-systems/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/vision-systems/server/templates/published-content/events.marko
+++ b/sites/vision-systems/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/vision-systems/server/templates/published-content/videos.marko
+++ b/sites/vision-systems/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/vision-systems/server/templates/published-content/webinars.marko
+++ b/sites/vision-systems/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/vision-systems/server/templates/published-content/webinars.marko
+++ b/sites/vision-systems/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/vision-systems/server/templates/published-content/white-papers.marko
+++ b/sites/vision-systems/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/waterworld/config/site.js
+++ b/sites/waterworld/config/site.js
@@ -38,7 +38,7 @@ module.exports = {
     resources: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
-      { href: '/white-papers', label: 'Whitepapers' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
     ],
     userTools: [

--- a/sites/waterworld/server/routes/published-content.js
+++ b/sites/waterworld/server/routes/published-content.js
@@ -5,7 +5,7 @@ const videos = require('../templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webcasts', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/waterworld/server/templates/published-content/events.marko
+++ b/sites/waterworld/server/templates/published-content/events.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content'
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Event"],
+  contentTypes: ['Event'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Events', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Events" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Events"
-    body=`The latest events from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/waterworld/server/templates/published-content/videos.marko
+++ b/sites/waterworld/server/templates/published-content/videos.marko
@@ -1,26 +1,19 @@
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-$ const { site, config } = out.global;
-$ const query = { contentTypes: ["Video"], limit: 10 };
-$ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1' }),
-  'gpt-ad-right1': getAdUnit(site, { name: 'rail1' }),
-};
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Video'], limit: 10 };
+$ const page = pageDetails('Videos', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Videos" />
-    <cms-ad-gam-head slots=adSlots />
+    <cms-ad-gam-head />
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Videos"
-    body=`The latest videos from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/waterworld/server/templates/published-content/webinars.marko
+++ b/sites/waterworld/server/templates/published-content/webinars.marko
@@ -1,16 +1,18 @@
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
+
 $ const { config } = out.global;
 $ const query = {
-  contentTypes: ["Webinar"],
+  contentTypes: ['Webinar'],
   limit: 9,
   sort: {
     field: 'startDate',
     order: 'desc',
   },
 };
+$ const page = pageDetails('Webcasts', config);
 
-<theme-pennwell-published-content-layout>
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -18,10 +20,7 @@ $ const query = {
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="Webcasts"
-    body=`The latest webcasts from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">

--- a/sites/waterworld/server/templates/published-content/webinars.marko
+++ b/sites/waterworld/server/templates/published-content/webinars.marko
@@ -10,7 +10,7 @@ $ const query = {
 
 <theme-pennwell-published-content-layout>
   <@head>
-    <cms-page-title value="Webinars" />
+    <cms-page-title value="Webcasts" />
     <cms-ad-gam-head />
   </@head>
 
@@ -19,8 +19,8 @@ $ const query = {
   </@above-container>
 
   <endeavor-content-block-page-title
-    header="Webinars"
-    body=`The latest webinars from ${config.siteName()}`
+    header="Webcasts"
+    body=`The latest webcasts from ${config.siteName()}`
   />
 
   <@below-container>

--- a/sites/waterworld/server/templates/published-content/white-papers.marko
+++ b/sites/waterworld/server/templates/published-content/white-papers.marko
@@ -1,9 +1,11 @@
-$ const { config } = out.global;
-$ const query = { contentTypes: ["Whitepaper"], limit: 9 };
+import { pageDetails } from '@endeavorb2b/base-website-common/utils/published-content';
 
-<theme-pennwell-published-content-layout>
+$ const { config } = out.global;
+$ const query = { contentTypes: ['Whitepaper'], limit: 9 };
+$ const page = pageDetails('White Papers', config);
+
+<theme-pennwell-published-content-layout page=page>
   <@head>
-    <cms-page-title value="White Papers" />
     <cms-ad-gam-head />
   </@head>
 
@@ -11,10 +13,7 @@ $ const query = { contentTypes: ["Whitepaper"], limit: 9 };
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-block-page-title
-    header="White Papers"
-    body=`The latest white papers from ${config.siteName()}`
-  />
+  <endeavor-content-block-page-title header=page.title body=page.description />
 
   <@below-container>
     <div class="published-content-query-load-more">


### PR DESCRIPTION
- ensure home page ads use the `inline` modifier instead of `home-page-inline`
- update `/webinars` route to `/webcasts`
- rename `Whitepapers` menu link label to `White Papers`
- set min-height to `content-card` blocks
- consolidate published content layout variables
- add primary images / media (video) to content pages
- create video "play button" image overlay
- decrease footer sizings on small screen sizes
- prevent displaying "Home" twice on content breadcrumbs
- hide user attribution and published dates on contact pages
- change content body margins to use bottom instead of top