### PR TITLE
Latest Issue homepage block

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ x-node-defaults: &node
   image: node:10.15
   entrypoint: ["node"]
   working_dir: /root
+  restart: always
   volumes:
     - .:/root:cached
     - ./node_modules:/root/node_modules:delegated

--- a/packages/common/components/content/blocks/query-load-more-issue-content.marko
+++ b/packages/common/components/content/blocks/query-load-more-issue-content.marko
@@ -1,49 +1,11 @@
-import gql from 'graphql-tag';
+
+import queryFragment from '@endeavorb2b/base-website-themes/pennwell/api/fragments/magazine-issue-content';
 import { asArray } from '@base-cms/utils';
 import { getAsObject } from '@base-cms/object-path';
 
 $ const pageNumber = input.pageNumber || 1;
 $ const { issueId } = getAsObject(input, 'query');
 $ const header = input.header || 'More from this issue';
-$ const queryFragment = gql`
-  fragment ContentBlockQueryMagazineIssueScheduledContentFragment on Content {
-    id
-    type
-    shortName
-    canonicalPath
-    published
-    company {
-      id
-      type
-      name
-      canonicalPath
-    }
-    primarySection {
-      id
-      name
-      fullName
-      canonicalPath
-    }
-    primaryImage {
-      id
-      src
-      alt
-    }
-    ... on Authorable {
-      authors {
-        edges {
-          node {
-            id
-            name
-            type
-            canonicalPath
-          }
-        }
-      }
-    }
-  }
-`;
-
 $ const block = 'magazine-query-issue-content';
 $ const query = {
   issueId,

--- a/packages/common/components/magazine/blocks/issue-element-group.marko
+++ b/packages/common/components/magazine/blocks/issue-element-group.marko
@@ -1,0 +1,16 @@
+import { getAsObject, getAsArray } from '@base-cms/object-path';
+
+$ const block = 'content-element-group';
+$ const modifiers = Array.isArray(input.modifiers) ? input.modifiers.map(mod => `${block}--${mod}`) : [];
+$ const classNames = [block, ...modifiers, input.class];
+
+$ const issue = getAsObject(input, 'issue');
+
+<div class=block>
+  <cms-website-section-name block=block obj=issue.publication link=true />
+  <cms-content-name block=block obj=issue link=true />
+  <small class=`${block}__row`>
+    <cms-link-element to=issue.publication path="subscribeUrl">Subscribe</cms-link-element>
+    <cms-date-element obj=issue block=block field="mailDate" />
+  </small>
+</div>

--- a/packages/common/components/magazine/blocks/issue.marko
+++ b/packages/common/components/magazine/blocks/issue.marko
@@ -1,0 +1,39 @@
+import latestIssueFragment from '@endeavorb2b/base-website-themes/pennwell/api/fragments/magazine-latest-issue';
+import queryFragment from '@endeavorb2b/base-website-themes/pennwell/api/fragments/magazine-issue-content';
+
+$ const { issue, vertical, content } = input;
+$ const block = 'magazine-current-issue';
+$ const withImage = input.withImage === false ? false : true;
+$ const modifiers = vertical ? ['vertical'] : ['horizontal'];
+
+<li class="content-list-group__item list-group-item">
+  <if(vertical)>
+    <div class=`${block}__vertical`>
+      <endeavor-magazine-issue-image issue=issue width=640 modifiers=modifiers />
+      <endeavor-magazine-issue-element-group issue=issue modifiers=modifiers />
+    </div>
+  </if>
+  <else>
+    <div class=`${block}__horizontal`>
+      <endeavor-magazine-issue-image issue=issue width=100 modifiers=modifiers />
+      <endeavor-magazine-issue-element-group issue=issue modifiers=modifiers />
+    </div>
+  </else>
+</li>
+
+<if(content > 0)>
+  $ const query = { issueId: issue.id, limit: content, queryFragment };
+  <cms-query-magazine-scheduled-content|{ nodes, pageInfo }| ...query>
+    <for|content| of=nodes>
+      <li class="content-list-group__item list-group-item">
+        <endeavor-content-block-item
+          content=content
+          image-modifiers=['list']
+          image-options={ w: 176, h: 99, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
+          modifiers=input.modifiers
+          with-image=input.withImage
+        />
+      </li>
+    </for>
+  </cms-query-magazine-scheduled-content>
+</if>

--- a/packages/common/components/magazine/blocks/marko.json
+++ b/packages/common/components/magazine/blocks/marko.json
@@ -1,7 +1,55 @@
 {
   "tags": {
     "endeavor-magazine-query-latest-issue": {
-      "template": "./query-latest-issue.marko"
+      "template": "./query-latest-issue.marko",
+      "@header": "string",
+      "@publicationId": {
+        "type": "string",
+        "required": true
+      },
+      "@vertical": {
+        "type": "boolean",
+        "default-value": false
+      },
+      "@content": {
+        "type": "number",
+        "default-value": 3
+      }
+    },
+    "endeavor-magazine-query-latest-issues": {
+      "template": "./query-latest-issues.marko",
+      "@header": "string",
+      "@vertical": {
+        "type": "boolean",
+        "default-value": false
+      },
+      "@content": {
+        "type": "number",
+        "default-value": 1
+      }
+    },
+    "endeavor-magazine-issue-block": {
+      "template": "./issue.marko",
+      "@issue": {
+        "type": "object",
+        "required": true
+      },
+      "@vertical": {
+        "type": "boolean",
+        "default-value": false
+      },
+      "@content": {
+        "type": "number",
+        "default-value": 0
+      }
+    },
+    "endeavor-magazine-issue-element-group": {
+      "template": "./issue-element-group.marko",
+      "@issue": {
+        "type": "object",
+        "required": true
+      },
+      "@modifiers": "array"
     },
     "endeavor-magazine-block-query-active-issues": {
       "template": "./query-active-issues.marko"

--- a/packages/common/components/magazine/blocks/query-latest-issue.marko
+++ b/packages/common/components/magazine/blocks/query-latest-issue.marko
@@ -1,6 +1,15 @@
-<div class="content-vertical-list card">
-  <div class="content-vertical-list__header card-header">
-    Current Issue
+import latestIssueFragment from '@endeavorb2b/base-website-themes/pennwell/api/fragments/magazine-latest-issue';
+
+$ const block = 'content-vertical-list';
+$ const { publicationId, vertical, content } = input;
+
+<cms-query-magazine-latest-issue|{ node }| publicationId=publicationId queryFragment=latestIssueFragment>
+  <div class=`${block} card`>
+    <if(input.header)>
+      <div class=`${block}__header card-header`>${input.header}</div>
+    </if>
+    <ul class='list-group list-group-flush'>
+      <endeavor-magazine-issue-block issue=node ...input />
+    </ul>
   </div>
-  <div class="card-body"></div>
-</div>
+</cms-query-magazine-latest-issue>

--- a/packages/common/components/magazine/blocks/query-latest-issues.marko
+++ b/packages/common/components/magazine/blocks/query-latest-issues.marko
@@ -1,0 +1,19 @@
+import publicationFragment from '@endeavorb2b/base-website-themes/pennwell/api/fragments/magazine-publication';
+import latestIssueFragment from '@endeavorb2b/base-website-themes/pennwell/api/fragments/magazine-latest-issue';
+
+$ const block = 'content-vertical-list';
+
+<cms-query-magazine-publications|{ nodes }| query-fragment=publicationFragment>
+  <div class=`${block} card`>
+    <if(input.header)>
+      <div class=`${block}__header card-header`>${input.header}</div>
+    </if>
+    <ul class="list-group list-group-flush">
+      <for|publication| of=nodes>
+        <cms-query-magazine-latest-issue|{ node }| publicationId=publication.id queryFragment=latestIssueFragment>
+          <endeavor-magazine-issue-block issue=node ...input />
+        </cms-query-magazine-latest-issue>
+      </for>
+    </ul>
+  </div>
+</cms-query-magazine-publications>

--- a/packages/common/components/magazine/elements/issue-image.marko
+++ b/packages/common/components/magazine/elements/issue-image.marko
@@ -1,0 +1,33 @@
+import { getAsObject } from '@base-cms/object-path';
+
+$ const issue = getAsObject(input, 'issue');
+$ const altText = issue.coverDescription || `${issue.name} Cover Image`;
+$ const { withLink } = input;
+$ const block = 'magazine-issue-image'
+
+<if(withLink)>
+  <cms-image-element
+    obj=issue.coverImage
+    alt=altText
+    class=`${block}__image`
+    link-to=issue
+    link-class=`${block}__image-link`
+    block=block
+    height=input.height
+    lazyload=input.lazyload
+    options=input.options
+    width=input.width
+  />
+</if>
+<else>
+  <cms-image-element
+    obj=issue.coverImage
+    alt=altText
+    class=`${block}__image`
+    block=block
+    height=input.height
+    lazyload=input.lazyload
+    options=input.options
+    width=input.width
+  />
+</else>

--- a/packages/common/components/magazine/elements/marko.json
+++ b/packages/common/components/magazine/elements/marko.json
@@ -5,6 +5,25 @@
     },
     "endeavor-magazine-issue-card": {
       "template": "./issue-card.marko"
+    },
+    "endeavor-magazine-issue-image": {
+      "template": "./issue-image.marko",
+      "@issue": {
+        "type": "object",
+        "required": true
+      },
+      "@lazyload": {
+        "type": "boolean",
+        "default-value": true
+      },
+      "@modifiers": "array",
+      "@options": "object",
+      "@width": "number",
+      "@height": "number",
+      "@with-link": {
+        "type": "boolean",
+        "default-value": true
+      }
     }
   }
 }

--- a/packages/themes/pennwell/api/fragments/magazine-issue-content.js
+++ b/packages/themes/pennwell/api/fragments/magazine-issue-content.js
@@ -1,0 +1,40 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+fragment ContentBlockQueryMagazineIssueScheduledContentFragment on Content {
+  id
+  type
+  shortName
+  canonicalPath
+  published
+  company {
+    id
+    type
+    name
+    canonicalPath
+  }
+  primarySection {
+    id
+    name
+    fullName
+    canonicalPath
+  }
+  primaryImage {
+    id
+    src
+    alt
+  }
+  ... on Authorable {
+    authors {
+      edges {
+        node {
+          id
+          name
+          type
+          canonicalPath
+        }
+      }
+    }
+  }
+}
+`;

--- a/packages/themes/pennwell/api/fragments/magazine-latest-issue.js
+++ b/packages/themes/pennwell/api/fragments/magazine-latest-issue.js
@@ -10,9 +10,11 @@ fragment MagazineLatestIssueQueryFragment on MagazineIssue {
     id
     src
   }
+  mailDate
   digitalEditionUrl
   publication {
     id
+    name
     canonicalPath
     subscribeUrl
   }

--- a/packages/themes/pennwell/styles/components/_magazine.scss
+++ b/packages/themes/pennwell/styles/components/_magazine.scss
@@ -1,6 +1,8 @@
 @import "magazine/breadcrumbs";
 @import "magazine/card";
+@import "magazine/current-issue";
 @import "magazine/issue-card";
+@import "magazine/issue-image";
 @import "magazine/page";
 @import "magazine/publication-details";
 @import "magazine/publication-list";

--- a/packages/themes/pennwell/styles/components/content/_element-group.scss
+++ b/packages/themes/pennwell/styles/components/content/_element-group.scss
@@ -4,7 +4,8 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  &__content-short-name {
+  &__content-short-name,
+  &__magazine-issue-name {
     min-height: 48px;
     max-height: 48px;
     margin-bottom: $element-margin;
@@ -25,7 +26,8 @@
       }
     }
   }
-  &__website-section-name {
+  &__website-section-name,
+  &__magazine-publication-name {
     @include theme-list-text();
     margin-bottom: $element-margin;
     color: $gray;
@@ -55,6 +57,7 @@
     }
   }
   &__content-published,
+  &__magazine-issue-mail-date,
   &__content-event-dates {
     @include theme-list-text();
     margin-top: auto;

--- a/packages/themes/pennwell/styles/components/magazine/_current-issue.scss
+++ b/packages/themes/pennwell/styles/components/magazine/_current-issue.scss
@@ -1,0 +1,24 @@
+.magazine-current-issue {
+  &__horizontal {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+  }
+  &__horizontal > a > img {
+    margin-top: auto;
+    margin-right: $list-group-item-padding-y;
+    margin-bottom: auto;
+    margin-left: -#{$list-group-item-padding-x - $list-group-item-padding-y};
+  }
+  &__vertical {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+  &__vertical > a > img {
+    width: calc(100% + 1rem);
+    margin-right: -#{$list-group-item-padding-x - $list-group-item-padding-y};
+    margin-bottom: $list-group-item-padding-y;
+    margin-left: -#{$list-group-item-padding-x - $list-group-item-padding-y};
+  }
+}

--- a/packages/themes/pennwell/styles/components/magazine/_issue-image.scss
+++ b/packages/themes/pennwell/styles/components/magazine/_issue-image.scss
@@ -1,0 +1,14 @@
+.magazine-issue-image {
+  $element-margin: 6px;
+  $self: &;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+
+  &__image {
+    display: block;
+    margin: 0 auto;
+    border-radius: $border-radius;
+    box-shadow: $theme-box-shadow-lg;
+  }
+}

--- a/sites/bioopticsworld/server/templates/index.marko
+++ b/sites/bioopticsworld/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/broadbandtechreport/server/templates/index.marko
+++ b/sites/broadbandtechreport/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/cablinginstall/server/templates/index.marko
+++ b/sites/cablinginstall/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/dentaleconomics/server/templates/index.marko
+++ b/sites/dentaleconomics/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/dentistryiq/server/templates/index.marko
+++ b/sites/dentistryiq/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/industrial-lasers/server/templates/index.marko
+++ b/sites/industrial-lasers/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/intelligent-aerospace/server/templates/index.marko
+++ b/sites/intelligent-aerospace/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/laserfocusworld/server/templates/index.marko
+++ b/sites/laserfocusworld/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/ledsmagazine/server/templates/index.marko
+++ b/sites/ledsmagazine/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/lightwaveonline/server/templates/index.marko
+++ b/sites/lightwaveonline/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/militaryaerospace/server/templates/index.marko
+++ b/sites/militaryaerospace/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/offshore-mag/server/templates/index.marko
+++ b/sites/offshore-mag/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/ogj/server/templates/index.marko
+++ b/sites/ogj/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/perioimplantadvisory/server/templates/index.marko
+++ b/sites/perioimplantadvisory/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/rdhmag/server/templates/index.marko
+++ b/sites/rdhmag/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/strategies-u/server/routes/content.js
+++ b/sites/strategies-u/server/routes/content.js
@@ -1,6 +1,5 @@
 const queryFragment = require('@endeavorb2b/base-website-themes/pennwell/api/fragments/content-page');
 const { withContent } = require('@base-cms/marko-web/middleware');
-require('bootstrap');
 const content = require('../templates/content');
 
 module.exports = (app) => {

--- a/sites/strategies-u/server/templates/index.marko
+++ b/sites/strategies-u/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/utilityproducts/server/templates/index.marko
+++ b/sites/utilityproducts/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/vision-systems/server/templates/index.marko
+++ b/sites/vision-systems/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 

--- a/sites/waterworld/server/templates/index.marko
+++ b/sites/waterworld/server/templates/index.marko
@@ -49,7 +49,7 @@ $ const adSlots = {
         query={
           requiresImage: true,
           contentTypes: ["Video"],
-          limit: 6,
+          limit: 4,
         }
         header="Videos"
       />
@@ -59,14 +59,14 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 6,
+          limit: 4,
         }
         with-image=false
         header="White Papers"
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue />
+      <endeavor-magazine-query-latest-issues content=3 header="Current Issue" />
     </div>
   </div>
 


### PR DESCRIPTION
Adds the following components:
- `<endeavor-magazine-query-latest-issue publicationId />`
- `<endeavor-magazine-query-latest-issues />`
- `<endeavor-magazine-issue />`
- `<endeavor-magazine-issue-image />`
- `<endeavor-magazine-issue-element-group />`

The two query blocks support the same set of parameters:
- `vertical` (boolean, default `false`) If the issue contents should be displayed in a vertical (card) format
- `content` (number, single default `3`, multi default `1`) the number of content items to display
- `header` (string) The block header to display

The `endeavor-magazine-query-latest-issue` block requires a `publicationId` -- the `endeavor-magazine-query-latest-issues` block is essentially just a wrapper for this block utilizing the `cms-magazine-publication-list` query to find active publications.

<img width="1149" alt="Screen Shot 2019-04-24 at 1 27 52 PM" src="https://user-images.githubusercontent.com/1778222/56688554-ab850c00-669e-11e9-8f0c-fa001b4f718d.png">
<img width="1150" alt="Screen Shot 2019-04-24 at 1 28 04 PM" src="https://user-images.githubusercontent.com/1778222/56688555-ab850c00-669e-11e9-940b-23dfdfd967d6.png">
<img width="1149" alt="Screen Shot 2019-04-24 at 1 28 39 PM" src="https://user-images.githubusercontent.com/1778222/56688558-ab850c00-669e-11e9-9277-cc83e621c905.png">
