### PR TITLE
Disable frameguard for preview mode

### DIFF
--- a/packages/common/on-start.js
+++ b/packages/common/on-start.js
@@ -3,5 +3,7 @@ const helmet = require('helmet');
 // Set global express settings/middlewares for _all_ websites that use this function.
 module.exports = (app) => {
   app.set('trust proxy', 'loopback, linklocal, uniquelocal');
-  app.use(helmet());
+  app.use(helmet({
+    frameguard: false,
+  }));
 };


### PR DESCRIPTION
Base displays the content preview via an iframe. The default `X-Frame-Options` header set by helmet restricts to `same-origin.` This removes that restriction so that `manage.` can display contents on `www.` via an iframe.