### PR TITLE
Reskin implementation

### DIFF
--- a/packages/common/browser/index.js
+++ b/packages/common/browser/index.js
@@ -4,11 +4,13 @@ import SearchIntegrationBing from './search-integration-bing.vue';
 import SearchIntegrationGoogle from './search-integration-google.vue';
 import GatedDownloadFormDotCom from './gated-download-form-dot-com.vue';
 import ContactUsForm from './contact-us-form.vue';
+import ReskinListener from './reskin-listener.vue';
 
 Browser.registerComponent('NavbarToggleButton', NavbarToggleButton);
 Browser.registerComponent('SearchIntegrationBing', SearchIntegrationBing);
 Browser.registerComponent('SearchIntegrationGoogle', SearchIntegrationGoogle);
 Browser.registerComponent('GatedDownloadFormDotCom', GatedDownloadFormDotCom);
 Browser.registerComponent('ContactUsForm', ContactUsForm);
+Browser.registerComponent('ReskinListener', ReskinListener);
 
 export default Browser;

--- a/packages/common/browser/reskin-listener.vue
+++ b/packages/common/browser/reskin-listener.vue
@@ -1,0 +1,67 @@
+<template>
+  <div />
+</template>
+
+<script>
+import $ from '@base-cms/marko-web/browser/jquery';
+
+const isJson = (str) => {
+  try {
+    JSON.parse(str);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+const defaults = {
+  backgroundColor: 'transparent',
+  boxShadow: 'no', // light, dark
+};
+
+/**
+ * Required:
+ * adImagePath
+ * adTitle
+ * backgroundImagePath
+ * adClickUrl
+ *
+ * Optional
+ * backgroundColor
+ * boxShadow
+ */
+const display = (payload) => {
+  const options = { ...defaults, ...payload };
+  const { adClickUrl: href, backgroundColor, backgroundImagePath } = options;
+  const { adImagePath: src, adTitle: alt } = options;
+  const backgroundImage = `url(" ${backgroundImagePath}")`;
+
+  const adContainer = $('<div />').addClass('reveal-ad').addClass(`reveal-ad--${options.boxShadow}-shadow`);
+  adContainer.html($('<a/>', { href, title: alt, target: '_blank' }).append($('<img />', { src, alt })));
+
+  const revealBackground = $('<a/>', { href, target: '_blank' }).addClass('reveal-background').css({ backgroundColor, backgroundImage });
+  $('body').prepend(revealBackground);
+
+  revealBackground.show();
+  $('.container-fluid-max > .ad-container').before(adContainer);
+  $('.container-fluid-max').append(adContainer.clone());
+};
+
+const listener = function (e) {
+  const payload = isJson(e.data) ? JSON.parse(e.data) : {};
+  if (['adImagePath', 'adTitle', 'backgroundImagePath', 'adClickUrl'].every(k => payload[k])) {
+    display(payload);
+    this.fired = true;
+    removeListener();
+  }
+};
+
+const removeListener = () => window.removeEventListener('message', listener, false);
+
+export default {
+  data: () => ({ fired: false }),
+  created() {
+    window.addEventListener('message', listener, false);
+  },
+};
+</script>

--- a/packages/common/browser/reskin-listener.vue
+++ b/packages/common/browser/reskin-listener.vue
@@ -39,8 +39,8 @@ const display = (payload) => {
   const adContainer = $('<div />').addClass('reveal-ad').addClass(`reveal-ad--${options.boxShadow}-shadow`);
   adContainer.html($('<a/>', { href, title: alt, target: '_blank' }).append($('<img />', { src, alt })));
 
-  const revealBackground = $('<a/>', { href, target: '_blank' }).addClass('reveal-background').css({ backgroundColor, backgroundImage });
-  $('body').prepend(revealBackground);
+  const revealBackground = $('<a/>', { href, target: '_blank' }).addClass('reveal-background').css({ backgroundImage });
+  $('body').css({ backgroundColor }).prepend(revealBackground);
 
   revealBackground.show();
   $('.container-fluid-max > .ad-container').before(adContainer);

--- a/packages/common/browser/reskin-listener.vue
+++ b/packages/common/browser/reskin-listener.vue
@@ -17,17 +17,6 @@ const defaults = {
   backgroundColor: 'transparent',
 };
 
-/**
- * Required:
- * adImagePath
- * adTitle
- * backgroundImagePath
- * adClickUrl
- *
- * Optional
- * backgroundColor
- * boxShadow
- */
 const display = (payload) => {
   const options = { ...defaults, ...payload };
   const { adClickUrl: href, backgroundColor, backgroundImagePath } = options;

--- a/packages/common/browser/reskin-listener.vue
+++ b/packages/common/browser/reskin-listener.vue
@@ -33,8 +33,6 @@ const display = (payload) => {
 
   const revealBackground = $('<a>', { href, target, rel }).addClass('reveal-ad-background').css({ backgroundImage });
   $('body').css({ backgroundColor }).prepend(revealBackground);
-
-  revealBackground.show();
   $('.container-fluid-max > .ad-container').before(adContainer);
   $('.container-fluid-max').append(adContainer.clone());
 };

--- a/packages/themes/pennwell/components/document.marko
+++ b/packages/themes/pennwell/components/document.marko
@@ -7,6 +7,7 @@
     <cms-ad-gam-init />
     <${input.head} />
   </@head>
+  <cms-browser-component name="ReskinListener" />
   <endeavor-load-icons icons=[
     "cross",
     "facebook",

--- a/packages/themes/pennwell/styles/components/_ads.scss
+++ b/packages/themes/pennwell/styles/components/_ads.scss
@@ -35,7 +35,7 @@
   }
 }
 
-.reveal-background {
+.reveal-ad-background {
   position: fixed;
   top: 0;
   left: 0;

--- a/packages/themes/pennwell/styles/components/_ads.scss
+++ b/packages/themes/pennwell/styles/components/_ads.scss
@@ -34,3 +34,27 @@
     }
   }
 }
+
+.reveal-background {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background-repeat: no-repeat;
+  background-position: top center;
+  background-size: cover;
+}
+
+.reveal-ad {
+  position: relative;
+  width: 300px;
+  margin: 0 auto map-get($spacers, block);
+  &--light-shadow {
+    box-shadow: 0 4px 8px 0 rgba(255, 255, 255, .2), 0 6px 20px 0 rgba(255, 255, 255, .19);
+  }
+  &--dark-shadow {
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, .2), 0 6px 20px 0 rgba(0, 0, 0, .19);
+  }
+}

--- a/sites/athleticbusiness/server/templates/contact-us/index.marko
+++ b/sites/athleticbusiness/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/athleticbusiness/server/templates/contact-us/index.marko
+++ b/sites/athleticbusiness/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/athleticbusiness/server/templates/content/index.marko
+++ b/sites/athleticbusiness/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -60,8 +62,5 @@ $ const adSlots = {
         ads={ aliases }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/athleticbusiness/server/templates/dynamic-page/index.marko
+++ b/sites/athleticbusiness/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/athleticbusiness/server/templates/index.marko
+++ b/sites/athleticbusiness/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -81,9 +83,6 @@ $ const adSlots = {
       }
       ads={ aliases }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/athleticbusiness/server/templates/index.marko
+++ b/sites/athleticbusiness/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/athleticbusiness/server/templates/magazine/index.marko
+++ b/sites/athleticbusiness/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/athleticbusiness/server/templates/magazine/issue.marko
+++ b/sites/athleticbusiness/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/athleticbusiness/server/templates/magazine/publication.marko
+++ b/sites/athleticbusiness/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/athleticbusiness/server/templates/published-content/events.marko
+++ b/sites/athleticbusiness/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/athleticbusiness/server/templates/published-content/videos.marko
+++ b/sites/athleticbusiness/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/athleticbusiness/server/templates/published-content/webinars.marko
+++ b/sites/athleticbusiness/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/athleticbusiness/server/templates/published-content/white-papers.marko
+++ b/sites/athleticbusiness/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/athleticbusiness/server/templates/search.marko
+++ b/sites/athleticbusiness/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/athleticbusiness/server/templates/search.marko
+++ b/sites/athleticbusiness/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/athleticbusiness/server/templates/subscribe/email.marko
+++ b/sites/athleticbusiness/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/athleticbusiness/server/templates/subscribe/index.marko
+++ b/sites/athleticbusiness/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/athleticbusiness/server/templates/subscribe/magazine.marko
+++ b/sites/athleticbusiness/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/athleticbusiness/server/templates/website-section/index.marko
+++ b/sites/athleticbusiness/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -51,7 +53,5 @@ $ const adSlots = {
       }
       ads={ aliases }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/bioopticsworld/server/templates/contact-us/index.marko
+++ b/sites/bioopticsworld/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/bioopticsworld/server/templates/contact-us/index.marko
+++ b/sites/bioopticsworld/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/bioopticsworld/server/templates/content/index.marko
+++ b/sites/bioopticsworld/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -62,8 +64,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/bioopticsworld/server/templates/dynamic-page/index.marko
+++ b/sites/bioopticsworld/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/bioopticsworld/server/templates/index.marko
+++ b/sites/bioopticsworld/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/bioopticsworld/server/templates/index.marko
+++ b/sites/bioopticsworld/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -84,9 +86,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/bioopticsworld/server/templates/magazine/index.marko
+++ b/sites/bioopticsworld/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/bioopticsworld/server/templates/magazine/issue.marko
+++ b/sites/bioopticsworld/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/bioopticsworld/server/templates/magazine/publication.marko
+++ b/sites/bioopticsworld/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/bioopticsworld/server/templates/published-content/events.marko
+++ b/sites/bioopticsworld/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/bioopticsworld/server/templates/published-content/videos.marko
+++ b/sites/bioopticsworld/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/bioopticsworld/server/templates/published-content/webinars.marko
+++ b/sites/bioopticsworld/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/bioopticsworld/server/templates/published-content/white-papers.marko
+++ b/sites/bioopticsworld/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/bioopticsworld/server/templates/search.marko
+++ b/sites/bioopticsworld/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/bioopticsworld/server/templates/search.marko
+++ b/sites/bioopticsworld/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/bioopticsworld/server/templates/subscribe/email.marko
+++ b/sites/bioopticsworld/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/bioopticsworld/server/templates/subscribe/index.marko
+++ b/sites/bioopticsworld/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/bioopticsworld/server/templates/subscribe/magazine.marko
+++ b/sites/bioopticsworld/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/bioopticsworld/server/templates/website-section/index.marko
+++ b/sites/bioopticsworld/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -54,7 +56,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/broadbandtechreport/server/templates/contact-us/index.marko
+++ b/sites/broadbandtechreport/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/broadbandtechreport/server/templates/contact-us/index.marko
+++ b/sites/broadbandtechreport/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/broadbandtechreport/server/templates/content/index.marko
+++ b/sites/broadbandtechreport/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -62,8 +64,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/broadbandtechreport/server/templates/dynamic-page/index.marko
+++ b/sites/broadbandtechreport/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/broadbandtechreport/server/templates/index.marko
+++ b/sites/broadbandtechreport/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -90,9 +92,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/broadbandtechreport/server/templates/index.marko
+++ b/sites/broadbandtechreport/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/broadbandtechreport/server/templates/magazine/index.marko
+++ b/sites/broadbandtechreport/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/broadbandtechreport/server/templates/magazine/issue.marko
+++ b/sites/broadbandtechreport/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/broadbandtechreport/server/templates/magazine/publication.marko
+++ b/sites/broadbandtechreport/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/broadbandtechreport/server/templates/published-content/events.marko
+++ b/sites/broadbandtechreport/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/broadbandtechreport/server/templates/published-content/videos.marko
+++ b/sites/broadbandtechreport/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/broadbandtechreport/server/templates/published-content/webinars.marko
+++ b/sites/broadbandtechreport/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/broadbandtechreport/server/templates/published-content/white-papers.marko
+++ b/sites/broadbandtechreport/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/broadbandtechreport/server/templates/search.marko
+++ b/sites/broadbandtechreport/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/broadbandtechreport/server/templates/search.marko
+++ b/sites/broadbandtechreport/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/broadbandtechreport/server/templates/subscribe/email.marko
+++ b/sites/broadbandtechreport/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/broadbandtechreport/server/templates/subscribe/index.marko
+++ b/sites/broadbandtechreport/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/broadbandtechreport/server/templates/subscribe/magazine.marko
+++ b/sites/broadbandtechreport/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/broadbandtechreport/server/templates/website-section/index.marko
+++ b/sites/broadbandtechreport/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -54,7 +56,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/cablinginstall/server/templates/contact-us/index.marko
+++ b/sites/cablinginstall/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/cablinginstall/server/templates/contact-us/index.marko
+++ b/sites/cablinginstall/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/cablinginstall/server/templates/content/index.marko
+++ b/sites/cablinginstall/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -62,8 +64,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/cablinginstall/server/templates/dynamic-page/index.marko
+++ b/sites/cablinginstall/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/cablinginstall/server/templates/index.marko
+++ b/sites/cablinginstall/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/cablinginstall/server/templates/index.marko
+++ b/sites/cablinginstall/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -84,9 +86,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/cablinginstall/server/templates/magazine/index.marko
+++ b/sites/cablinginstall/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/cablinginstall/server/templates/magazine/issue.marko
+++ b/sites/cablinginstall/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/cablinginstall/server/templates/magazine/publication.marko
+++ b/sites/cablinginstall/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/cablinginstall/server/templates/published-content/events.marko
+++ b/sites/cablinginstall/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/cablinginstall/server/templates/published-content/videos.marko
+++ b/sites/cablinginstall/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/cablinginstall/server/templates/published-content/webinars.marko
+++ b/sites/cablinginstall/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/cablinginstall/server/templates/published-content/white-papers.marko
+++ b/sites/cablinginstall/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/cablinginstall/server/templates/search.marko
+++ b/sites/cablinginstall/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/cablinginstall/server/templates/search.marko
+++ b/sites/cablinginstall/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/cablinginstall/server/templates/subscribe/email.marko
+++ b/sites/cablinginstall/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/cablinginstall/server/templates/subscribe/index.marko
+++ b/sites/cablinginstall/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/cablinginstall/server/templates/subscribe/magazine.marko
+++ b/sites/cablinginstall/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/cablinginstall/server/templates/website-section/index.marko
+++ b/sites/cablinginstall/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -54,7 +56,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/dentaleconomics/server/templates/contact-us/index.marko
+++ b/sites/dentaleconomics/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/dentaleconomics/server/templates/contact-us/index.marko
+++ b/sites/dentaleconomics/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/dentaleconomics/server/templates/content/index.marko
+++ b/sites/dentaleconomics/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -63,8 +65,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/dentaleconomics/server/templates/dynamic-page/index.marko
+++ b/sites/dentaleconomics/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/dentaleconomics/server/templates/index.marko
+++ b/sites/dentaleconomics/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -85,9 +87,6 @@ $ const adSlots = {
       native-x={ placement: 'card', aliases, index: 0 }
       ads={ aliases }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/dentaleconomics/server/templates/index.marko
+++ b/sites/dentaleconomics/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/dentaleconomics/server/templates/magazine/index.marko
+++ b/sites/dentaleconomics/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/dentaleconomics/server/templates/magazine/issue.marko
+++ b/sites/dentaleconomics/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/dentaleconomics/server/templates/magazine/publication.marko
+++ b/sites/dentaleconomics/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/dentaleconomics/server/templates/published-content/events.marko
+++ b/sites/dentaleconomics/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/dentaleconomics/server/templates/published-content/videos.marko
+++ b/sites/dentaleconomics/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/dentaleconomics/server/templates/published-content/webinars.marko
+++ b/sites/dentaleconomics/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/dentaleconomics/server/templates/published-content/white-papers.marko
+++ b/sites/dentaleconomics/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/dentaleconomics/server/templates/search.marko
+++ b/sites/dentaleconomics/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/dentaleconomics/server/templates/search.marko
+++ b/sites/dentaleconomics/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/dentaleconomics/server/templates/subscribe/email.marko
+++ b/sites/dentaleconomics/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/dentaleconomics/server/templates/subscribe/index.marko
+++ b/sites/dentaleconomics/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/dentaleconomics/server/templates/subscribe/magazine.marko
+++ b/sites/dentaleconomics/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/dentaleconomics/server/templates/website-section/index.marko
+++ b/sites/dentaleconomics/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,7 +57,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/dentistryiq/server/templates/contact-us/index.marko
+++ b/sites/dentistryiq/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/dentistryiq/server/templates/contact-us/index.marko
+++ b/sites/dentistryiq/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/dentistryiq/server/templates/content/index.marko
+++ b/sites/dentistryiq/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -63,8 +65,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/dentistryiq/server/templates/dynamic-page/index.marko
+++ b/sites/dentistryiq/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/dentistryiq/server/templates/index.marko
+++ b/sites/dentistryiq/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -127,9 +129,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/dentistryiq/server/templates/index.marko
+++ b/sites/dentistryiq/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/dentistryiq/server/templates/magazine/index.marko
+++ b/sites/dentistryiq/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/dentistryiq/server/templates/magazine/issue.marko
+++ b/sites/dentistryiq/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/dentistryiq/server/templates/magazine/publication.marko
+++ b/sites/dentistryiq/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/dentistryiq/server/templates/published-content/events.marko
+++ b/sites/dentistryiq/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/dentistryiq/server/templates/published-content/videos.marko
+++ b/sites/dentistryiq/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/dentistryiq/server/templates/published-content/webinars.marko
+++ b/sites/dentistryiq/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/dentistryiq/server/templates/published-content/white-papers.marko
+++ b/sites/dentistryiq/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/dentistryiq/server/templates/search.marko
+++ b/sites/dentistryiq/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/dentistryiq/server/templates/search.marko
+++ b/sites/dentistryiq/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/dentistryiq/server/templates/subscribe/email.marko
+++ b/sites/dentistryiq/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/dentistryiq/server/templates/subscribe/index.marko
+++ b/sites/dentistryiq/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/dentistryiq/server/templates/subscribe/magazine.marko
+++ b/sites/dentistryiq/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/dentistryiq/server/templates/website-section/index.marko
+++ b/sites/dentistryiq/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,7 +57,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/dentistryiq/server/templates/website-section/products-free-samples.marko
+++ b/sites/dentistryiq/server/templates/website-section/products-free-samples.marko
@@ -57,8 +57,4 @@ $ const aliases = hierarchyAliases(section);
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
-  </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/dentistryiq/server/templates/website-section/products-free-samples.marko
+++ b/sites/dentistryiq/server/templates/website-section/products-free-samples.marko
@@ -11,8 +11,8 @@ $ const aliases = hierarchyAliases(section);
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] aliases=aliases />
   </@above-container>
 

--- a/sites/dentistryiq/server/templates/website-section/products-free-samples.marko
+++ b/sites/dentistryiq/server/templates/website-section/products-free-samples.marko
@@ -11,6 +11,8 @@ $ const aliases = hierarchyAliases(section);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] aliases=aliases />
   </@above-container>
 

--- a/sites/evaluationengineering/server/templates/contact-us/index.marko
+++ b/sites/evaluationengineering/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/evaluationengineering/server/templates/contact-us/index.marko
+++ b/sites/evaluationengineering/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/evaluationengineering/server/templates/content/index.marko
+++ b/sites/evaluationengineering/server/templates/content/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -61,8 +63,5 @@ $ const adSlots = {
         }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/evaluationengineering/server/templates/dynamic-page/index.marko
+++ b/sites/evaluationengineering/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/evaluationengineering/server/templates/index.marko
+++ b/sites/evaluationengineering/server/templates/index.marko
@@ -17,8 +17,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/evaluationengineering/server/templates/index.marko
+++ b/sites/evaluationengineering/server/templates/index.marko
@@ -17,6 +17,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -53,9 +55,6 @@ $ const adSlots = {
         card: { name: "HP" },
       }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/evaluationengineering/server/templates/magazine/index.marko
+++ b/sites/evaluationengineering/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/evaluationengineering/server/templates/magazine/issue.marko
+++ b/sites/evaluationengineering/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -49,8 +51,6 @@ $ const publication = getAsObject(issue, 'publication');
         list: { name: "MR" },
       }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/evaluationengineering/server/templates/magazine/publication.marko
+++ b/sites/evaluationengineering/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const publication = getAsObject(data, 'publication');
       }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/evaluationengineering/server/templates/published-content/events.marko
+++ b/sites/evaluationengineering/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/evaluationengineering/server/templates/published-content/videos.marko
+++ b/sites/evaluationengineering/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,8 +38,6 @@ $ const page = pageDetails('Videos', config);
         }
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/evaluationengineering/server/templates/published-content/webinars.marko
+++ b/sites/evaluationengineering/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/evaluationengineering/server/templates/published-content/white-papers.marko
+++ b/sites/evaluationengineering/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/evaluationengineering/server/templates/search.marko
+++ b/sites/evaluationengineering/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/evaluationengineering/server/templates/search.marko
+++ b/sites/evaluationengineering/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/evaluationengineering/server/templates/subscribe/email.marko
+++ b/sites/evaluationengineering/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/evaluationengineering/server/templates/subscribe/index.marko
+++ b/sites/evaluationengineering/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/evaluationengineering/server/templates/subscribe/magazine.marko
+++ b/sites/evaluationengineering/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/evaluationengineering/server/templates/website-section/index.marko
+++ b/sites/evaluationengineering/server/templates/website-section/index.marko
@@ -10,6 +10,8 @@ $ const aliases = hierarchyAliases(section);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" aliases=aliases modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/evaluationengineering/server/templates/website-section/index.marko
+++ b/sites/evaluationengineering/server/templates/website-section/index.marko
@@ -10,8 +10,8 @@ $ const aliases = hierarchyAliases(section);
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-define-display name="BS" aliases=aliases modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/evaluationengineering/server/templates/website-section/index.marko
+++ b/sites/evaluationengineering/server/templates/website-section/index.marko
@@ -32,7 +32,5 @@ $ const aliases = hierarchyAliases(section);
         card: { name: "HP" },
       }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/industrial-lasers/server/templates/contact-us/index.marko
+++ b/sites/industrial-lasers/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/industrial-lasers/server/templates/contact-us/index.marko
+++ b/sites/industrial-lasers/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/industrial-lasers/server/templates/content/index.marko
+++ b/sites/industrial-lasers/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -62,8 +64,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/industrial-lasers/server/templates/dynamic-page/index.marko
+++ b/sites/industrial-lasers/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/industrial-lasers/server/templates/index.marko
+++ b/sites/industrial-lasers/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/industrial-lasers/server/templates/index.marko
+++ b/sites/industrial-lasers/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -84,9 +86,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/industrial-lasers/server/templates/magazine/index.marko
+++ b/sites/industrial-lasers/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/industrial-lasers/server/templates/magazine/issue.marko
+++ b/sites/industrial-lasers/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/industrial-lasers/server/templates/magazine/publication.marko
+++ b/sites/industrial-lasers/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/industrial-lasers/server/templates/published-content/events.marko
+++ b/sites/industrial-lasers/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/industrial-lasers/server/templates/published-content/videos.marko
+++ b/sites/industrial-lasers/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/industrial-lasers/server/templates/published-content/webinars.marko
+++ b/sites/industrial-lasers/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/industrial-lasers/server/templates/published-content/white-papers.marko
+++ b/sites/industrial-lasers/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/industrial-lasers/server/templates/search.marko
+++ b/sites/industrial-lasers/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/industrial-lasers/server/templates/search.marko
+++ b/sites/industrial-lasers/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/industrial-lasers/server/templates/subscribe/email.marko
+++ b/sites/industrial-lasers/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/industrial-lasers/server/templates/subscribe/index.marko
+++ b/sites/industrial-lasers/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/industrial-lasers/server/templates/subscribe/magazine.marko
+++ b/sites/industrial-lasers/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/industrial-lasers/server/templates/website-section/index.marko
+++ b/sites/industrial-lasers/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -54,7 +56,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/intelligent-aerospace/server/templates/contact-us/index.marko
+++ b/sites/intelligent-aerospace/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/intelligent-aerospace/server/templates/contact-us/index.marko
+++ b/sites/intelligent-aerospace/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/intelligent-aerospace/server/templates/content/index.marko
+++ b/sites/intelligent-aerospace/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -62,8 +64,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/intelligent-aerospace/server/templates/dynamic-page/index.marko
+++ b/sites/intelligent-aerospace/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/intelligent-aerospace/server/templates/index.marko
+++ b/sites/intelligent-aerospace/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/intelligent-aerospace/server/templates/index.marko
+++ b/sites/intelligent-aerospace/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -84,9 +86,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/intelligent-aerospace/server/templates/magazine/index.marko
+++ b/sites/intelligent-aerospace/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/intelligent-aerospace/server/templates/magazine/issue.marko
+++ b/sites/intelligent-aerospace/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/intelligent-aerospace/server/templates/magazine/publication.marko
+++ b/sites/intelligent-aerospace/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/intelligent-aerospace/server/templates/published-content/events.marko
+++ b/sites/intelligent-aerospace/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/intelligent-aerospace/server/templates/published-content/videos.marko
+++ b/sites/intelligent-aerospace/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/intelligent-aerospace/server/templates/published-content/webinars.marko
+++ b/sites/intelligent-aerospace/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/intelligent-aerospace/server/templates/published-content/white-papers.marko
+++ b/sites/intelligent-aerospace/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/intelligent-aerospace/server/templates/search.marko
+++ b/sites/intelligent-aerospace/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/intelligent-aerospace/server/templates/search.marko
+++ b/sites/intelligent-aerospace/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/intelligent-aerospace/server/templates/subscribe/email.marko
+++ b/sites/intelligent-aerospace/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/intelligent-aerospace/server/templates/subscribe/index.marko
+++ b/sites/intelligent-aerospace/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/intelligent-aerospace/server/templates/subscribe/magazine.marko
+++ b/sites/intelligent-aerospace/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/intelligent-aerospace/server/templates/website-section/index.marko
+++ b/sites/intelligent-aerospace/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -54,7 +56,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/laserfocusworld/server/templates/contact-us/index.marko
+++ b/sites/laserfocusworld/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/laserfocusworld/server/templates/contact-us/index.marko
+++ b/sites/laserfocusworld/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/laserfocusworld/server/templates/content/index.marko
+++ b/sites/laserfocusworld/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -62,8 +64,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/laserfocusworld/server/templates/dynamic-page/index.marko
+++ b/sites/laserfocusworld/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/laserfocusworld/server/templates/index.marko
+++ b/sites/laserfocusworld/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/laserfocusworld/server/templates/index.marko
+++ b/sites/laserfocusworld/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -84,9 +86,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/laserfocusworld/server/templates/magazine/index.marko
+++ b/sites/laserfocusworld/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/laserfocusworld/server/templates/magazine/issue.marko
+++ b/sites/laserfocusworld/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/laserfocusworld/server/templates/magazine/publication.marko
+++ b/sites/laserfocusworld/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/laserfocusworld/server/templates/published-content/events.marko
+++ b/sites/laserfocusworld/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/laserfocusworld/server/templates/published-content/videos.marko
+++ b/sites/laserfocusworld/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/laserfocusworld/server/templates/published-content/webinars.marko
+++ b/sites/laserfocusworld/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/laserfocusworld/server/templates/published-content/white-papers.marko
+++ b/sites/laserfocusworld/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/laserfocusworld/server/templates/search.marko
+++ b/sites/laserfocusworld/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/laserfocusworld/server/templates/search.marko
+++ b/sites/laserfocusworld/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/laserfocusworld/server/templates/subscribe/email.marko
+++ b/sites/laserfocusworld/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/laserfocusworld/server/templates/subscribe/index.marko
+++ b/sites/laserfocusworld/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/laserfocusworld/server/templates/subscribe/magazine.marko
+++ b/sites/laserfocusworld/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/laserfocusworld/server/templates/website-section/index.marko
+++ b/sites/laserfocusworld/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -54,7 +56,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/ledsmagazine/server/templates/contact-us/index.marko
+++ b/sites/ledsmagazine/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/ledsmagazine/server/templates/contact-us/index.marko
+++ b/sites/ledsmagazine/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/ledsmagazine/server/templates/content/index.marko
+++ b/sites/ledsmagazine/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -62,8 +64,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/ledsmagazine/server/templates/dynamic-page/index.marko
+++ b/sites/ledsmagazine/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/ledsmagazine/server/templates/index.marko
+++ b/sites/ledsmagazine/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/ledsmagazine/server/templates/index.marko
+++ b/sites/ledsmagazine/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -84,9 +86,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/ledsmagazine/server/templates/magazine/index.marko
+++ b/sites/ledsmagazine/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/ledsmagazine/server/templates/magazine/issue.marko
+++ b/sites/ledsmagazine/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/ledsmagazine/server/templates/magazine/publication.marko
+++ b/sites/ledsmagazine/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/ledsmagazine/server/templates/published-content/events.marko
+++ b/sites/ledsmagazine/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/ledsmagazine/server/templates/published-content/videos.marko
+++ b/sites/ledsmagazine/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/ledsmagazine/server/templates/published-content/webinars.marko
+++ b/sites/ledsmagazine/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/ledsmagazine/server/templates/published-content/white-papers.marko
+++ b/sites/ledsmagazine/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/ledsmagazine/server/templates/search.marko
+++ b/sites/ledsmagazine/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/ledsmagazine/server/templates/search.marko
+++ b/sites/ledsmagazine/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/ledsmagazine/server/templates/subscribe/email.marko
+++ b/sites/ledsmagazine/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/ledsmagazine/server/templates/subscribe/index.marko
+++ b/sites/ledsmagazine/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/ledsmagazine/server/templates/subscribe/magazine.marko
+++ b/sites/ledsmagazine/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/ledsmagazine/server/templates/website-section/index.marko
+++ b/sites/ledsmagazine/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -54,7 +56,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/lightwaveonline/server/templates/contact-us/index.marko
+++ b/sites/lightwaveonline/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/lightwaveonline/server/templates/contact-us/index.marko
+++ b/sites/lightwaveonline/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/lightwaveonline/server/templates/content/index.marko
+++ b/sites/lightwaveonline/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -62,8 +64,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/lightwaveonline/server/templates/dynamic-page/index.marko
+++ b/sites/lightwaveonline/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/lightwaveonline/server/templates/index.marko
+++ b/sites/lightwaveonline/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -90,9 +92,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/lightwaveonline/server/templates/index.marko
+++ b/sites/lightwaveonline/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/lightwaveonline/server/templates/magazine/index.marko
+++ b/sites/lightwaveonline/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/lightwaveonline/server/templates/magazine/issue.marko
+++ b/sites/lightwaveonline/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/lightwaveonline/server/templates/magazine/publication.marko
+++ b/sites/lightwaveonline/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/lightwaveonline/server/templates/published-content/events.marko
+++ b/sites/lightwaveonline/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/lightwaveonline/server/templates/published-content/videos.marko
+++ b/sites/lightwaveonline/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/lightwaveonline/server/templates/published-content/webinars.marko
+++ b/sites/lightwaveonline/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/lightwaveonline/server/templates/published-content/white-papers.marko
+++ b/sites/lightwaveonline/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/lightwaveonline/server/templates/search.marko
+++ b/sites/lightwaveonline/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/lightwaveonline/server/templates/search.marko
+++ b/sites/lightwaveonline/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/lightwaveonline/server/templates/subscribe/email.marko
+++ b/sites/lightwaveonline/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/lightwaveonline/server/templates/subscribe/index.marko
+++ b/sites/lightwaveonline/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/lightwaveonline/server/templates/subscribe/magazine.marko
+++ b/sites/lightwaveonline/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/lightwaveonline/server/templates/website-section/index.marko
+++ b/sites/lightwaveonline/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -54,7 +56,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/militaryaerospace/server/templates/contact-us/index.marko
+++ b/sites/militaryaerospace/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/militaryaerospace/server/templates/contact-us/index.marko
+++ b/sites/militaryaerospace/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/militaryaerospace/server/templates/content/index.marko
+++ b/sites/militaryaerospace/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -62,8 +64,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/militaryaerospace/server/templates/dynamic-page/index.marko
+++ b/sites/militaryaerospace/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/militaryaerospace/server/templates/index.marko
+++ b/sites/militaryaerospace/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/militaryaerospace/server/templates/index.marko
+++ b/sites/militaryaerospace/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -84,9 +86,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/militaryaerospace/server/templates/magazine/index.marko
+++ b/sites/militaryaerospace/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/militaryaerospace/server/templates/magazine/issue.marko
+++ b/sites/militaryaerospace/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/militaryaerospace/server/templates/magazine/publication.marko
+++ b/sites/militaryaerospace/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/militaryaerospace/server/templates/published-content/events.marko
+++ b/sites/militaryaerospace/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/militaryaerospace/server/templates/published-content/videos.marko
+++ b/sites/militaryaerospace/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/militaryaerospace/server/templates/published-content/webinars.marko
+++ b/sites/militaryaerospace/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/militaryaerospace/server/templates/published-content/white-papers.marko
+++ b/sites/militaryaerospace/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/militaryaerospace/server/templates/search.marko
+++ b/sites/militaryaerospace/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/militaryaerospace/server/templates/search.marko
+++ b/sites/militaryaerospace/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/militaryaerospace/server/templates/subscribe/email.marko
+++ b/sites/militaryaerospace/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/militaryaerospace/server/templates/subscribe/index.marko
+++ b/sites/militaryaerospace/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/militaryaerospace/server/templates/subscribe/magazine.marko
+++ b/sites/militaryaerospace/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/militaryaerospace/server/templates/website-section/index.marko
+++ b/sites/militaryaerospace/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -54,7 +56,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/officer/server/templates/contact-us/index.marko
+++ b/sites/officer/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/officer/server/templates/contact-us/index.marko
+++ b/sites/officer/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/officer/server/templates/content/index.marko
+++ b/sites/officer/server/templates/content/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -61,8 +63,5 @@ $ const adSlots = {
         }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/officer/server/templates/dynamic-page/index.marko
+++ b/sites/officer/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/officer/server/templates/index.marko
+++ b/sites/officer/server/templates/index.marko
@@ -17,8 +17,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/officer/server/templates/index.marko
+++ b/sites/officer/server/templates/index.marko
@@ -17,6 +17,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -53,9 +55,6 @@ $ const adSlots = {
         card: { name: "HP" },
       }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/officer/server/templates/magazine/index.marko
+++ b/sites/officer/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/officer/server/templates/magazine/issue.marko
+++ b/sites/officer/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/officer/server/templates/magazine/publication.marko
+++ b/sites/officer/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const publication = getAsObject(data, 'publication');
       }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/officer/server/templates/published-content/events.marko
+++ b/sites/officer/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/officer/server/templates/published-content/videos.marko
+++ b/sites/officer/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,8 +38,6 @@ $ const page = pageDetails('Videos', config);
         }
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/officer/server/templates/published-content/webinars.marko
+++ b/sites/officer/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/officer/server/templates/published-content/white-papers.marko
+++ b/sites/officer/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/officer/server/templates/search.marko
+++ b/sites/officer/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/officer/server/templates/search.marko
+++ b/sites/officer/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/officer/server/templates/subscribe/email.marko
+++ b/sites/officer/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/officer/server/templates/subscribe/index.marko
+++ b/sites/officer/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/officer/server/templates/subscribe/magazine.marko
+++ b/sites/officer/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/officer/server/templates/website-section/index.marko
+++ b/sites/officer/server/templates/website-section/index.marko
@@ -10,6 +10,8 @@ $ const aliases = hierarchyAliases(section);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" aliases=aliases modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/officer/server/templates/website-section/index.marko
+++ b/sites/officer/server/templates/website-section/index.marko
@@ -10,8 +10,8 @@ $ const aliases = hierarchyAliases(section);
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-define-display name="BS" aliases=aliases modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/officer/server/templates/website-section/index.marko
+++ b/sites/officer/server/templates/website-section/index.marko
@@ -32,7 +32,5 @@ $ const aliases = hierarchyAliases(section);
         card: { name: "HP" },
       }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/offshore-mag/server/templates/contact-us/index.marko
+++ b/sites/offshore-mag/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/offshore-mag/server/templates/contact-us/index.marko
+++ b/sites/offshore-mag/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/offshore-mag/server/templates/content/index.marko
+++ b/sites/offshore-mag/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -62,8 +64,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/offshore-mag/server/templates/dynamic-page/index.marko
+++ b/sites/offshore-mag/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/offshore-mag/server/templates/index.marko
+++ b/sites/offshore-mag/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/offshore-mag/server/templates/index.marko
+++ b/sites/offshore-mag/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -84,9 +86,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/offshore-mag/server/templates/magazine/index.marko
+++ b/sites/offshore-mag/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/offshore-mag/server/templates/magazine/issue.marko
+++ b/sites/offshore-mag/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/offshore-mag/server/templates/magazine/publication.marko
+++ b/sites/offshore-mag/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/offshore-mag/server/templates/published-content/events.marko
+++ b/sites/offshore-mag/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/offshore-mag/server/templates/published-content/videos.marko
+++ b/sites/offshore-mag/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/offshore-mag/server/templates/published-content/webinars.marko
+++ b/sites/offshore-mag/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/offshore-mag/server/templates/published-content/white-papers.marko
+++ b/sites/offshore-mag/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/offshore-mag/server/templates/search.marko
+++ b/sites/offshore-mag/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/offshore-mag/server/templates/search.marko
+++ b/sites/offshore-mag/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/offshore-mag/server/templates/subscribe/email.marko
+++ b/sites/offshore-mag/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/offshore-mag/server/templates/subscribe/index.marko
+++ b/sites/offshore-mag/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/offshore-mag/server/templates/subscribe/magazine.marko
+++ b/sites/offshore-mag/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/offshore-mag/server/templates/website-section/index.marko
+++ b/sites/offshore-mag/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -54,7 +56,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/ogj/server/templates/contact-us/index.marko
+++ b/sites/ogj/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,4 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/ogj/server/templates/content/index.marko
+++ b/sites/ogj/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -60,8 +62,5 @@ $ const adSlots = {
         ads={ aliases }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/ogj/server/templates/dynamic-page/index.marko
+++ b/sites/ogj/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,8 +28,4 @@ $ const page = getAsObject(data, 'page');
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/ogj/server/templates/index.marko
+++ b/sites/ogj/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -81,9 +83,6 @@ $ const adSlots = {
       }
       ads={ aliases }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/ogj/server/templates/magazine/index.marko
+++ b/sites/ogj/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -27,8 +29,4 @@ $ const description = site.get('magazines.description');
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/ogj/server/templates/magazine/issue.marko
+++ b/sites/ogj/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/ogj/server/templates/magazine/publication.marko
+++ b/sites/ogj/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,6 @@ $ const publication = getAsObject(data, 'publication');
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/ogj/server/templates/published-content/events.marko
+++ b/sites/ogj/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/ogj/server/templates/published-content/videos.marko
+++ b/sites/ogj/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/ogj/server/templates/published-content/webinars.marko
+++ b/sites/ogj/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/ogj/server/templates/published-content/white-papers.marko
+++ b/sites/ogj/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/ogj/server/templates/search.marko
+++ b/sites/ogj/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,4 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-search-layout>

--- a/sites/ogj/server/templates/subscribe/email.marko
+++ b/sites/ogj/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,4 @@ import { get, getAsObject } from '@base-cms/object-path';
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/ogj/server/templates/subscribe/index.marko
+++ b/sites/ogj/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/ogj/server/templates/subscribe/magazine.marko
+++ b/sites/ogj/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,8 +28,4 @@ $ const publication = getAsObject(data, 'publication');
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/ogj/server/templates/website-section/index.marko
+++ b/sites/ogj/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -51,7 +53,5 @@ $ const adSlots = {
       }
       ads={ aliases }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/perioimplantadvisory/server/templates/contact-us/index.marko
+++ b/sites/perioimplantadvisory/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/perioimplantadvisory/server/templates/contact-us/index.marko
+++ b/sites/perioimplantadvisory/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/perioimplantadvisory/server/templates/content/index.marko
+++ b/sites/perioimplantadvisory/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -63,8 +65,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/perioimplantadvisory/server/templates/dynamic-page/index.marko
+++ b/sites/perioimplantadvisory/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/perioimplantadvisory/server/templates/index.marko
+++ b/sites/perioimplantadvisory/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -85,9 +87,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/perioimplantadvisory/server/templates/index.marko
+++ b/sites/perioimplantadvisory/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/perioimplantadvisory/server/templates/magazine/index.marko
+++ b/sites/perioimplantadvisory/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/perioimplantadvisory/server/templates/magazine/issue.marko
+++ b/sites/perioimplantadvisory/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/perioimplantadvisory/server/templates/magazine/publication.marko
+++ b/sites/perioimplantadvisory/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/perioimplantadvisory/server/templates/published-content/events.marko
+++ b/sites/perioimplantadvisory/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/perioimplantadvisory/server/templates/published-content/videos.marko
+++ b/sites/perioimplantadvisory/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/perioimplantadvisory/server/templates/published-content/webinars.marko
+++ b/sites/perioimplantadvisory/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/perioimplantadvisory/server/templates/published-content/white-papers.marko
+++ b/sites/perioimplantadvisory/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/perioimplantadvisory/server/templates/search.marko
+++ b/sites/perioimplantadvisory/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/perioimplantadvisory/server/templates/search.marko
+++ b/sites/perioimplantadvisory/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/perioimplantadvisory/server/templates/subscribe/email.marko
+++ b/sites/perioimplantadvisory/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/perioimplantadvisory/server/templates/subscribe/index.marko
+++ b/sites/perioimplantadvisory/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/perioimplantadvisory/server/templates/subscribe/magazine.marko
+++ b/sites/perioimplantadvisory/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/perioimplantadvisory/server/templates/website-section/index.marko
+++ b/sites/perioimplantadvisory/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,7 +57,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/contact-us/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/contact-us/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/content/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/content/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -61,8 +63,5 @@ $ const adSlots = {
         }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/dynamic-page/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/index.marko
@@ -17,8 +17,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/plasticsmachinerymagazine/server/templates/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/index.marko
@@ -17,6 +17,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -53,9 +55,6 @@ $ const adSlots = {
         card: { name: "HP" },
       }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/magazine/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/magazine/issue.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -49,8 +51,6 @@ $ const publication = getAsObject(issue, 'publication');
         list: { name: "MR" },
       }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/magazine/publication.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const publication = getAsObject(data, 'publication');
       }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/published-content/events.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/published-content/videos.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,8 +38,6 @@ $ const page = pageDetails('Videos', config);
         }
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/published-content/webinars.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/published-content/white-papers.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/search.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/search.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/subscribe/email.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/subscribe/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/subscribe/magazine.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/website-section/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/website-section/index.marko
@@ -10,6 +10,8 @@ $ const aliases = hierarchyAliases(section);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="BS" aliases=aliases modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/plasticsmachinerymagazine/server/templates/website-section/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/website-section/index.marko
@@ -10,8 +10,8 @@ $ const aliases = hierarchyAliases(section);
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-define-display name="BS" aliases=aliases modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/plasticsmachinerymagazine/server/templates/website-section/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/website-section/index.marko
@@ -32,7 +32,5 @@ $ const aliases = hierarchyAliases(section);
         card: { name: "HP" },
       }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/rdhmag/server/templates/contact-us/index.marko
+++ b/sites/rdhmag/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/rdhmag/server/templates/contact-us/index.marko
+++ b/sites/rdhmag/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/rdhmag/server/templates/content/index.marko
+++ b/sites/rdhmag/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -63,8 +65,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/rdhmag/server/templates/dynamic-page/index.marko
+++ b/sites/rdhmag/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/rdhmag/server/templates/index.marko
+++ b/sites/rdhmag/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -85,9 +87,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/rdhmag/server/templates/index.marko
+++ b/sites/rdhmag/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/rdhmag/server/templates/magazine/index.marko
+++ b/sites/rdhmag/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/rdhmag/server/templates/magazine/issue.marko
+++ b/sites/rdhmag/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/rdhmag/server/templates/magazine/publication.marko
+++ b/sites/rdhmag/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/rdhmag/server/templates/published-content/events.marko
+++ b/sites/rdhmag/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/rdhmag/server/templates/published-content/videos.marko
+++ b/sites/rdhmag/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/rdhmag/server/templates/published-content/webinars.marko
+++ b/sites/rdhmag/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/rdhmag/server/templates/published-content/white-papers.marko
+++ b/sites/rdhmag/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/rdhmag/server/templates/search.marko
+++ b/sites/rdhmag/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/rdhmag/server/templates/search.marko
+++ b/sites/rdhmag/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/rdhmag/server/templates/subscribe/email.marko
+++ b/sites/rdhmag/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/rdhmag/server/templates/subscribe/index.marko
+++ b/sites/rdhmag/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/rdhmag/server/templates/subscribe/magazine.marko
+++ b/sites/rdhmag/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/rdhmag/server/templates/website-section/index.marko
+++ b/sites/rdhmag/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,7 +57,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/strategies-u/server/templates/contact-us/index.marko
+++ b/sites/strategies-u/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/strategies-u/server/templates/contact-us/index.marko
+++ b/sites/strategies-u/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/strategies-u/server/templates/content/index.marko
+++ b/sites/strategies-u/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -62,8 +64,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/strategies-u/server/templates/dynamic-page/index.marko
+++ b/sites/strategies-u/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/strategies-u/server/templates/index.marko
+++ b/sites/strategies-u/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/strategies-u/server/templates/index.marko
+++ b/sites/strategies-u/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -84,9 +86,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/strategies-u/server/templates/magazine/index.marko
+++ b/sites/strategies-u/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/strategies-u/server/templates/magazine/issue.marko
+++ b/sites/strategies-u/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/strategies-u/server/templates/magazine/publication.marko
+++ b/sites/strategies-u/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/strategies-u/server/templates/published-content/events.marko
+++ b/sites/strategies-u/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/strategies-u/server/templates/published-content/videos.marko
+++ b/sites/strategies-u/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/strategies-u/server/templates/published-content/webinars.marko
+++ b/sites/strategies-u/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/strategies-u/server/templates/published-content/white-papers.marko
+++ b/sites/strategies-u/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/strategies-u/server/templates/search.marko
+++ b/sites/strategies-u/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/strategies-u/server/templates/search.marko
+++ b/sites/strategies-u/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/strategies-u/server/templates/subscribe/email.marko
+++ b/sites/strategies-u/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/strategies-u/server/templates/subscribe/index.marko
+++ b/sites/strategies-u/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/strategies-u/server/templates/subscribe/magazine.marko
+++ b/sites/strategies-u/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/strategies-u/server/templates/website-section/index.marko
+++ b/sites/strategies-u/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -54,7 +56,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/utilityproducts/server/templates/contact-us/index.marko
+++ b/sites/utilityproducts/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/utilityproducts/server/templates/contact-us/index.marko
+++ b/sites/utilityproducts/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/utilityproducts/server/templates/content/index.marko
+++ b/sites/utilityproducts/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -62,8 +64,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/utilityproducts/server/templates/dynamic-page/index.marko
+++ b/sites/utilityproducts/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/utilityproducts/server/templates/index.marko
+++ b/sites/utilityproducts/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/utilityproducts/server/templates/index.marko
+++ b/sites/utilityproducts/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -84,9 +86,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/utilityproducts/server/templates/magazine/index.marko
+++ b/sites/utilityproducts/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/utilityproducts/server/templates/magazine/issue.marko
+++ b/sites/utilityproducts/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/utilityproducts/server/templates/magazine/publication.marko
+++ b/sites/utilityproducts/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/utilityproducts/server/templates/published-content/events.marko
+++ b/sites/utilityproducts/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/utilityproducts/server/templates/published-content/videos.marko
+++ b/sites/utilityproducts/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/utilityproducts/server/templates/published-content/webinars.marko
+++ b/sites/utilityproducts/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/utilityproducts/server/templates/published-content/white-papers.marko
+++ b/sites/utilityproducts/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/utilityproducts/server/templates/search.marko
+++ b/sites/utilityproducts/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/utilityproducts/server/templates/search.marko
+++ b/sites/utilityproducts/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/utilityproducts/server/templates/subscribe/email.marko
+++ b/sites/utilityproducts/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/utilityproducts/server/templates/subscribe/index.marko
+++ b/sites/utilityproducts/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/utilityproducts/server/templates/subscribe/magazine.marko
+++ b/sites/utilityproducts/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/utilityproducts/server/templates/website-section/index.marko
+++ b/sites/utilityproducts/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -54,7 +56,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/vision-systems/server/templates/contact-us/index.marko
+++ b/sites/vision-systems/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/vision-systems/server/templates/contact-us/index.marko
+++ b/sites/vision-systems/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/vision-systems/server/templates/content/index.marko
+++ b/sites/vision-systems/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -62,8 +64,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/vision-systems/server/templates/dynamic-page/index.marko
+++ b/sites/vision-systems/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/vision-systems/server/templates/index.marko
+++ b/sites/vision-systems/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/vision-systems/server/templates/index.marko
+++ b/sites/vision-systems/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -84,9 +86,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/vision-systems/server/templates/magazine/index.marko
+++ b/sites/vision-systems/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/vision-systems/server/templates/magazine/issue.marko
+++ b/sites/vision-systems/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/vision-systems/server/templates/magazine/publication.marko
+++ b/sites/vision-systems/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/vision-systems/server/templates/published-content/events.marko
+++ b/sites/vision-systems/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/vision-systems/server/templates/published-content/videos.marko
+++ b/sites/vision-systems/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/vision-systems/server/templates/published-content/webinars.marko
+++ b/sites/vision-systems/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/vision-systems/server/templates/published-content/white-papers.marko
+++ b/sites/vision-systems/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/vision-systems/server/templates/search.marko
+++ b/sites/vision-systems/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/vision-systems/server/templates/search.marko
+++ b/sites/vision-systems/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/vision-systems/server/templates/subscribe/email.marko
+++ b/sites/vision-systems/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/vision-systems/server/templates/subscribe/index.marko
+++ b/sites/vision-systems/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/vision-systems/server/templates/subscribe/magazine.marko
+++ b/sites/vision-systems/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/vision-systems/server/templates/website-section/index.marko
+++ b/sites/vision-systems/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -54,7 +56,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/waterworld/server/templates/contact-us/index.marko
+++ b/sites/waterworld/server/templates/contact-us/index.marko
@@ -56,6 +56,4 @@ $ const query = {
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-website-section-layout>

--- a/sites/waterworld/server/templates/contact-us/index.marko
+++ b/sites/waterworld/server/templates/contact-us/index.marko
@@ -16,6 +16,8 @@ $ const query = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -55,8 +57,5 @@ $ const query = {
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-website-section-layout>

--- a/sites/waterworld/server/templates/content/index.marko
+++ b/sites/waterworld/server/templates/content/index.marko
@@ -20,6 +20,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -62,8 +64,5 @@ $ const adSlots = {
         native-x={ placement: 'card', aliases, index: 0 }
       />
     </if>
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/waterworld/server/templates/dynamic-page/index.marko
+++ b/sites/waterworld/server/templates/dynamic-page/index.marko
@@ -7,6 +7,8 @@ $ const page = getAsObject(data, 'page');
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const page = getAsObject(data, 'page');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-dynamic-page-layout>

--- a/sites/waterworld/server/templates/index.marko
+++ b/sites/waterworld/server/templates/index.marko
@@ -19,8 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/waterworld/server/templates/index.marko
+++ b/sites/waterworld/server/templates/index.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -84,9 +86,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/waterworld/server/templates/magazine/index.marko
+++ b/sites/waterworld/server/templates/magazine/index.marko
@@ -7,6 +7,8 @@ $ const description = site.get('magazines.description');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -26,9 +28,4 @@ $ const description = site.get('magazines.description');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-magazine-layout>

--- a/sites/waterworld/server/templates/magazine/issue.marko
+++ b/sites/waterworld/server/templates/magazine/issue.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(issue, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -45,8 +47,6 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-content-query-load-more-issue-content
       query={ issueId: issue.id }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-issue-layout>

--- a/sites/waterworld/server/templates/magazine/publication.marko
+++ b/sites/waterworld/server/templates/magazine/publication.marko
@@ -8,6 +8,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -37,8 +39,6 @@ $ const publication = getAsObject(data, 'publication');
       query={ publicationId: publication.id }
     />
 
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-magazine-publication-layout>

--- a/sites/waterworld/server/templates/published-content/events.marko
+++ b/sites/waterworld/server/templates/published-content/events.marko
@@ -16,6 +16,8 @@ $ const page = pageDetails('Events', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -40,8 +42,6 @@ $ const page = pageDetails('Events', config);
         layout="event"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/waterworld/server/templates/published-content/videos.marko
+++ b/sites/waterworld/server/templates/published-content/videos.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('Videos', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -33,8 +35,6 @@ $ const page = pageDetails('Videos', config);
         query=query
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/waterworld/server/templates/published-content/webinars.marko
+++ b/sites/waterworld/server/templates/published-content/webinars.marko
@@ -15,6 +15,8 @@ $ const page = pageDetails('Webcasts', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -39,8 +41,6 @@ $ const page = pageDetails('Webcasts', config);
         layout="webinar"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/waterworld/server/templates/published-content/white-papers.marko
+++ b/sites/waterworld/server/templates/published-content/white-papers.marko
@@ -10,6 +10,8 @@ $ const page = pageDetails('White Papers', config);
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -34,8 +36,6 @@ $ const page = pageDetails('White Papers', config);
         layout="whitepaper"
       />
     </div>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
   </@below-container>
 
 </theme-pennwell-published-content-layout>

--- a/sites/waterworld/server/templates/search.marko
+++ b/sites/waterworld/server/templates/search.marko
@@ -24,6 +24,4 @@ $ const { config } = out.global;
       </div>
     </div>
   </div>
-
-
 </theme-pennwell-search-layout>

--- a/sites/waterworld/server/templates/search.marko
+++ b/sites/waterworld/server/templates/search.marko
@@ -6,6 +6,8 @@ $ const { config } = out.global;
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -23,8 +25,5 @@ $ const { config } = out.global;
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
+
 </theme-pennwell-search-layout>

--- a/sites/waterworld/server/templates/subscribe/email.marko
+++ b/sites/waterworld/server/templates/subscribe/email.marko
@@ -6,6 +6,8 @@ import { get, getAsObject } from '@base-cms/object-path';
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -22,9 +24,4 @@ import { get, getAsObject } from '@base-cms/object-path';
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/waterworld/server/templates/subscribe/index.marko
+++ b/sites/waterworld/server/templates/subscribe/index.marko
@@ -10,6 +10,8 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -36,9 +38,4 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/waterworld/server/templates/subscribe/magazine.marko
+++ b/sites/waterworld/server/templates/subscribe/magazine.marko
@@ -9,6 +9,8 @@ $ const publication = getAsObject(data, 'publication');
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -25,9 +27,4 @@ $ const publication = getAsObject(data, 'publication');
       </div>
     </div>
   </div>
-
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@below-container>
 </theme-pennwell-subscribe-layout>

--- a/sites/waterworld/server/templates/website-section/global-thought-leaders.marko
+++ b/sites/waterworld/server/templates/website-section/global-thought-leaders.marko
@@ -143,8 +143,4 @@ $ const aliases = hierarchyAliases(section);
     </div>
   </div>
 
-  <@below-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
-  </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/waterworld/server/templates/website-section/global-thought-leaders.marko
+++ b/sites/waterworld/server/templates/website-section/global-thought-leaders.marko
@@ -22,8 +22,8 @@ $ const aliases = hierarchyAliases(section);
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases  />
     <endeavor-gam-ad-unit-define-display name="lb1" aliases=aliases modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/waterworld/server/templates/website-section/global-thought-leaders.marko
+++ b/sites/waterworld/server/templates/website-section/global-thought-leaders.marko
@@ -22,6 +22,8 @@ $ const aliases = hierarchyAliases(section);
     <endeavor-ad-gam-head />
   </@head>
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" />
     <endeavor-gam-ad-unit-define-display name="lb1" aliases=aliases modifiers=["top-of-page"] />
   </@above-container>
 

--- a/sites/waterworld/server/templates/website-section/index.marko
+++ b/sites/waterworld/server/templates/website-section/index.marko
@@ -18,6 +18,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -54,7 +56,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/waterworld/server/templates/website-section/industrial.marko
+++ b/sites/waterworld/server/templates/website-section/industrial.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -70,7 +72,5 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 </theme-pennwell-website-section-layout>

--- a/sites/waterworld/server/templates/website-section/international.marko
+++ b/sites/waterworld/server/templates/website-section/international.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -62,8 +64,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/waterworld/server/templates/website-section/municipal-technologies.marko
+++ b/sites/waterworld/server/templates/website-section/municipal-technologies.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -79,8 +81,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>

--- a/sites/waterworld/server/templates/website-section/municipal.marko
+++ b/sites/waterworld/server/templates/website-section/municipal.marko
@@ -19,6 +19,8 @@ $ const adSlots = {
   </@head>
 
   <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
@@ -82,8 +84,6 @@ $ const adSlots = {
       ads={ aliases }
       native-x={ placement: 'card', aliases, index: 0 }
     />
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@below-container>
 
 </theme-pennwell-website-section-layout>


### PR DESCRIPTION
Handler for the Reskin/Reveal ad unit with the added option of `boxShadow` for cleaner presentation.
```js
/** Reskin Payload */
{
  // Required
  adImagePath,
  adTitle,
  backgroundImagePath,
  adClickUrl,
  // Optional
  backgroundColor,
  boxShadow,
}
```

- [x] OOP units need to be moved to the top/above-container slots for in-view macros to fire properly
I've done this for OGJ, but will wait for review to clutter up with the other 500 template changes :)

Default (none)  | Light Shadow | Dark Shadow
------------- | ------------- | ------------- 
![screencapture-0-0-0-0-12166-2019-05-13-16_28_16](https://user-images.githubusercontent.com/1778222/57656271-8dc00e00-759d-11e9-8968-1db67c30ee8a.jpg) | ![screencapture-0-0-0-0-12166-2019-05-13-16_29_01](https://user-images.githubusercontent.com/1778222/57656272-8dc00e00-759d-11e9-9f42-2d0e54b61521.jpg) | ![screencapture-0-0-0-0-12166-2019-05-13-16_29_49](https://user-images.githubusercontent.com/1778222/57656273-8dc00e00-759d-11e9-9683-5db221d49bb5.jpg)