### PR TITLE
Linkable list header support

### DIFF
--- a/packages/common/components/content/blocks/query-section-list.marko
+++ b/packages/common/components/content/blocks/query-section-list.marko
@@ -19,13 +19,14 @@ $ const nativeXEnabled = useNativeX(site, {
   aliases: nativeX.aliases,
 });
 $ const imageOptions = { w: 120, h: 120, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 };
+$ const header = getAsObject(input, 'header');
 
 <cms-query-website-scheduled-content|{ nodes }| ...params>
   <if(nodes.length)>
     <endeavor-item-list flush=true card=true items=nodes>
-      <if(input.header)>
-        <@header>
-          ${input.header}
+      <if(header.title)>
+        <@header href=header.href target=header.target>
+          ${header.title}
         </@header>
       </if>
       <@item|{ item, index }|>

--- a/packages/common/components/item/list-header.marko
+++ b/packages/common/components/item/list-header.marko
@@ -5,6 +5,13 @@ $ const classNames = bem('item-list', 'item', ['header', ...getAsArray(input, 'm
 
 <if(input.renderBody)>
   <${input.tag} class=classNames>
-    <${input.renderBody} />
+    <if(input.href)>
+      <endeavor-link href=input.href target=input.target title=input.title>
+        <${input.renderBody} />
+      </endeavor-link>
+    </if>
+    <else>
+      <${input.renderBody} />
+    </else>
   </>
 </if>

--- a/packages/common/components/item/list.marko
+++ b/packages/common/components/item/list.marko
@@ -12,9 +12,7 @@ $ const headerInput = getAsObject(input, 'header');
     tag=input.tag
   >
     <if(headerInput.renderBody)>
-      <endeavor-item-list-header tag=headerInput.tag modifiers=headerInput.modifiers>
-        <${headerInput.renderBody} />
-      </endeavor-item-list-header>
+      <endeavor-item-list-header ...headerInput />
     </if>
 
     <for|node, index| of=items>

--- a/packages/common/components/magazine/blocks/query-latest-issue.marko
+++ b/packages/common/components/magazine/blocks/query-latest-issue.marko
@@ -6,7 +6,7 @@ $ const { publicationId, asCard, contentCount } = input;
 <cms-query-magazine-latest-issue|{ node: issueNode }| publicationId=publicationId queryFragment=issueListFragment>
   <endeavor-item-list-wrapper flush=true card=true>
     <if(input.header)>
-      <endeavor-item-list-header>
+      <endeavor-item-list-header href=issueNode.canonicalPath>
         ${input.header}
       </endeavor-item-list-header>
     </if>

--- a/packages/common/components/marko.json
+++ b/packages/common/components/marko.json
@@ -96,7 +96,11 @@
         "@tag": {
           "type": "string",
           "default-value": "li"
-        }
+        },
+        "@modifiers": "array",
+        "@href": "string",
+        "@target": "string",
+        "@title": "string"
       },
       "@items": "array",
       "@tag": {
@@ -135,7 +139,10 @@
       "@tag": {
         "type": "string",
         "default-value": "li"
-      }
+      },
+      "@href": "string",
+      "@target": "string",
+      "@title": "string"
     },
     "endeavor-item-list-node": {
       "template": "./item/list-node",

--- a/packages/themes/pennwell/components/published-content/query.marko
+++ b/packages/themes/pennwell/components/published-content/query.marko
@@ -8,6 +8,7 @@ $ const { beginningAfter, beginningBefore } = input.query;
 $ const { endingAfter, endingBefore } = input.query;
 $ const layout = input.layout || 'grid';
 $ const ads = getAsObject(input, 'ads');
+$ const header = getAsObject(input, 'header');
 $ input.withImage = input.withImage === false ? false : true;
 $ input.withCard = input.withCard === true ? true : false;
 
@@ -61,9 +62,9 @@ $ const adCardInput = {
   <else>
     <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
     <endeavor-item-list flush=true card=true items=nodes>
-      <if(input.header)>
-        <@header>
-          ${input.header}
+      <if(header.title)>
+        <@header href=header.href target=header.target>
+          ${header.title}
         </@header>
       </if>
       <@item|{ item }|>

--- a/packages/themes/pennwell/styles/bootstrap/_mixins.scss
+++ b/packages/themes/pennwell/styles/bootstrap/_mixins.scss
@@ -225,9 +225,13 @@
   box-shadow: $theme-card-box-shadow;
 }
 
-@mixin theme-card-header() {
-  font-family: $theme-content-sans-serif-font;
+@mixin theme-card-header-color() {
   color: $white;
+}
+
+@mixin theme-card-header() {
+  @include theme-card-header-color();
+  font-family: $theme-content-sans-serif-font;
   text-transform: uppercase;
   letter-spacing: 1px;
   background-color: $primary;

--- a/packages/themes/pennwell/styles/components/_item-list.scss
+++ b/packages/themes/pennwell/styles/components/_item-list.scss
@@ -38,6 +38,10 @@
       &:last-child {
         @include border-bottom-radius(0);
       }
+
+      a {
+        @include theme-card-header-color();
+      }
     }
   }
 

--- a/sites/athleticbusiness/server/templates/index.marko
+++ b/sites/athleticbusiness/server/templates/index.marko
@@ -53,7 +53,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/athleticbusiness/server/templates/index.marko
+++ b/sites/athleticbusiness/server/templates/index.marko
@@ -64,7 +64,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/bioopticsworld/server/templates/index.marko
+++ b/sites/bioopticsworld/server/templates/index.marko
@@ -66,7 +66,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/bioopticsworld/server/templates/index.marko
+++ b/sites/bioopticsworld/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/broadbandtechreport/server/templates/index.marko
+++ b/sites/broadbandtechreport/server/templates/index.marko
@@ -75,7 +75,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="Webcasts"
+        header={ title: "Webcasts", href: "/webcasts" }
       />
     </div>
   </div>

--- a/sites/broadbandtechreport/server/templates/index.marko
+++ b/sites/broadbandtechreport/server/templates/index.marko
@@ -65,7 +65,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/broadbandtechreport/server/templates/index.marko
+++ b/sites/broadbandtechreport/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/cablinginstall/server/templates/index.marko
+++ b/sites/cablinginstall/server/templates/index.marko
@@ -66,7 +66,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/cablinginstall/server/templates/index.marko
+++ b/sites/cablinginstall/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/dentaleconomics/server/templates/index.marko
+++ b/sites/dentaleconomics/server/templates/index.marko
@@ -66,7 +66,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/dentaleconomics/server/templates/index.marko
+++ b/sites/dentaleconomics/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/dentistryiq/server/templates/index.marko
+++ b/sites/dentistryiq/server/templates/index.marko
@@ -39,7 +39,7 @@ $ const adSlots = {
           <endeavor-content-query-section-list
             limit=4
             section-alias="dental-hygiene"
-            header="Dental Hygiene"
+            header={ title: "Dental Hygiene", href: "/dental-hygiene" }
             native-x={ placement: 'list1', aliases: ['dental-hygiene'], index: 3 }
           />
         </div>
@@ -47,7 +47,7 @@ $ const adSlots = {
           <endeavor-content-query-section-list
             limit=4
             section-alias="clinical"
-            header="Clinical"
+            header={ title: "Clinical", href: "/clinical" }
             native-x={ placement: 'list1', aliases: ['clinical'], index: 3 }
           />
         </div>
@@ -63,7 +63,7 @@ $ const adSlots = {
       <endeavor-content-query-section-list
         limit=3
         section-alias="products"
-        header="Products"
+        header={ title: "Products", href: "/products" }
         native-x={ placement: 'list1', aliases: ['products'], index: 2 }
       />
     </div>
@@ -71,7 +71,7 @@ $ const adSlots = {
       <endeavor-content-query-section-list
         limit=3
         section-alias="practice-management"
-        header="Practice Management"
+        header={ title: "Practice Management", href: "/practice-management" }
         native-x={ placement: 'list1', aliases: ['practice-management'], index: 2 }
       />
     </div>
@@ -91,7 +91,7 @@ $ const adSlots = {
       <endeavor-content-query-section-list
         limit=3
         section-alias="front-office"
-        header="Front Office"
+        header={ title: "Front Office", href: "/front-office" }
         native-x={ placement: 'list1', aliases: ['front-office'], index: 2 }
       />
     </div>
@@ -99,7 +99,7 @@ $ const adSlots = {
       <endeavor-content-query-section-list
         limit=3
         section-alias="dental-assisting"
-        header="Dental Assisting"
+        header={ title: "Dental Assisting", href: "/dental-assisting" }
         native-x={ placement: 'list1', aliases: ['dental-assisting'], index: 2 }
       />
     </div>

--- a/sites/dentistryiq/server/templates/index.marko
+++ b/sites/dentistryiq/server/templates/index.marko
@@ -111,7 +111,7 @@ $ const adSlots = {
           limit: 3,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
   </div>

--- a/sites/dentistryiq/server/templates/index.marko
+++ b/sites/dentistryiq/server/templates/index.marko
@@ -82,7 +82,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 3,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
   </div>

--- a/sites/industrial-lasers/server/templates/index.marko
+++ b/sites/industrial-lasers/server/templates/index.marko
@@ -66,7 +66,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/industrial-lasers/server/templates/index.marko
+++ b/sites/industrial-lasers/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/intelligent-aerospace/server/templates/index.marko
+++ b/sites/intelligent-aerospace/server/templates/index.marko
@@ -66,7 +66,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/intelligent-aerospace/server/templates/index.marko
+++ b/sites/intelligent-aerospace/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/laserfocusworld/server/templates/index.marko
+++ b/sites/laserfocusworld/server/templates/index.marko
@@ -66,7 +66,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/laserfocusworld/server/templates/index.marko
+++ b/sites/laserfocusworld/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/ledsmagazine/server/templates/index.marko
+++ b/sites/ledsmagazine/server/templates/index.marko
@@ -66,7 +66,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/ledsmagazine/server/templates/index.marko
+++ b/sites/ledsmagazine/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/lightwaveonline/server/templates/index.marko
+++ b/sites/lightwaveonline/server/templates/index.marko
@@ -75,7 +75,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="Webcasts"
+        header={ title: "Webcasts", href: "/webcasts" }
       />
     </div>
   </div>

--- a/sites/lightwaveonline/server/templates/index.marko
+++ b/sites/lightwaveonline/server/templates/index.marko
@@ -65,7 +65,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/lightwaveonline/server/templates/index.marko
+++ b/sites/lightwaveonline/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/militaryaerospace/server/templates/index.marko
+++ b/sites/militaryaerospace/server/templates/index.marko
@@ -66,7 +66,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/militaryaerospace/server/templates/index.marko
+++ b/sites/militaryaerospace/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/offshore-mag/server/templates/index.marko
+++ b/sites/offshore-mag/server/templates/index.marko
@@ -66,7 +66,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/offshore-mag/server/templates/index.marko
+++ b/sites/offshore-mag/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/ogj/server/templates/index.marko
+++ b/sites/ogj/server/templates/index.marko
@@ -53,7 +53,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/ogj/server/templates/index.marko
+++ b/sites/ogj/server/templates/index.marko
@@ -64,7 +64,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/perioimplantadvisory/server/templates/index.marko
+++ b/sites/perioimplantadvisory/server/templates/index.marko
@@ -66,7 +66,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/perioimplantadvisory/server/templates/index.marko
+++ b/sites/perioimplantadvisory/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/rdhmag/server/templates/index.marko
+++ b/sites/rdhmag/server/templates/index.marko
@@ -66,7 +66,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/rdhmag/server/templates/index.marko
+++ b/sites/rdhmag/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/strategies-u/server/templates/index.marko
+++ b/sites/strategies-u/server/templates/index.marko
@@ -66,7 +66,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/strategies-u/server/templates/index.marko
+++ b/sites/strategies-u/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/utilityproducts/server/templates/index.marko
+++ b/sites/utilityproducts/server/templates/index.marko
@@ -66,7 +66,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/utilityproducts/server/templates/index.marko
+++ b/sites/utilityproducts/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/vision-systems/server/templates/index.marko
+++ b/sites/vision-systems/server/templates/index.marko
@@ -66,7 +66,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/vision-systems/server/templates/index.marko
+++ b/sites/vision-systems/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/waterworld/server/templates/index.marko
+++ b/sites/waterworld/server/templates/index.marko
@@ -55,7 +55,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
     <div class="col-lg-4 mb-block">
@@ -66,11 +66,14 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header="White Papers"
+        header={ title: "White Papers", href: "/webcasts" }
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue publication-id="5ca26a8b08cf3add038b45b7" header="Current Issue" />
+      <endeavor-magazine-query-latest-issue
+        publication-id="5ca26a8b08cf3add038b45b7"
+        header="Current Issue"
+      />
     </div>
   </div>
 

--- a/sites/waterworld/server/templates/index.marko
+++ b/sites/waterworld/server/templates/index.marko
@@ -66,7 +66,7 @@ $ const adSlots = {
           limit: 4,
         }
         with-image=false
-        header={ title: "White Papers", href: "/webcasts" }
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/waterworld/server/templates/website-section/industrial.marko
+++ b/sites/waterworld/server/templates/website-section/industrial.marko
@@ -34,10 +34,19 @@ $ const adSlots = {
 
   <div class="row">
     <div class="col-lg-4 mb-block">
-      <endeavor-content-query-section-list section-alias="industrial/process-water" header="Process Water" />
+      <endeavor-content-query-section-list
+        section-alias="industrial/process-water"
+        header={ title: "Process Water", href: "/industrial/process-water" }
+        limit=6
+      />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue publication-id="5cc1f22975a2547f1b0041aa" header="Industrial Water World" as-card=true content-count=0 />
+      <endeavor-magazine-query-latest-issue
+        publication-id="5cc1f22975a2547f1b0041aa"
+        header="Industrial Water World"
+        as-card=true
+        content-count=2
+      />
     </div>
     <div class="col-lg-4 ad-rail">
       <endeavor-gam-ad-unit-display id="gpt-ad-rail1" />
@@ -47,10 +56,16 @@ $ const adSlots = {
 
   <div class="row">
     <div class="col-lg-4 mb-block">
-      <endeavor-content-query-section-list section-alias="industrial/wastewater" header="Wastewater" />
+      <endeavor-content-query-section-list
+        section-alias="industrial/wastewater"
+        header={ title: "Wastewater", href: "/industrial/wastewater" }
+      />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-content-query-section-list section-alias="industrial/water-reuse" header="Water Reuse" />
+      <endeavor-content-query-section-list
+        section-alias="industrial/water-reuse"
+        header={ title: "Water Reuse", href: "/industrial/water-reuse" }
+      />
     </div>
     <div class="col-lg-4 mb-block">
       <theme-pennwell-published-content-query-list
@@ -58,7 +73,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
   </div>

--- a/sites/waterworld/server/templates/website-section/international.marko
+++ b/sites/waterworld/server/templates/website-section/international.marko
@@ -36,16 +36,32 @@ $ const adSlots = {
     <div class="col-lg-8">
       <div class="row">
         <div class="col-lg-6 mb-block">
-          <endeavor-content-query-section-list limit=3 section-alias="international/desalination" header="Desalination" />
+          <endeavor-content-query-section-list
+            limit=3
+            section-alias="international/desalination"
+            header={ title: "Desalination", href: "/international/desalination" }
+          />
         </div>
         <div class="col-lg-6 mb-block">
-          <endeavor-content-query-section-list limit=3 section-alias="international/potable-water" header="Potable Water" />
+          <endeavor-content-query-section-list
+            limit=3
+            section-alias="international/potable-water"
+            header={ title: "Potable Water", href: "/international/potable-water" }
+          />
         </div>
         <div class="col-lg-6 mb-block">
-          <endeavor-content-query-section-list limit=3 section-alias="international/utilities" header="Utilities" />
+          <endeavor-content-query-section-list
+            limit=3
+            section-alias="international/utilities"
+            header={ title: "Utilities", href: "/international/utilities" }
+          />
         </div>
         <div class="col-lg-6 mb-block">
-          <endeavor-content-query-section-list limit=3 section-alias="international/wastewater" header="Wastewater" />
+          <endeavor-content-query-section-list
+            limit=3
+            section-alias="international/wastewater"
+            header={ title: "Wastewater", href: "/international/wastewater" }
+          />
         </div>
       </div>
     </div>

--- a/sites/waterworld/server/templates/website-section/municipal-technologies.marko
+++ b/sites/waterworld/server/templates/website-section/municipal-technologies.marko
@@ -34,16 +34,32 @@ $ const adSlots = {
     <div class="col-lg-8">
       <div class="row">
         <div class="col-lg-6 mb-block">
-          <endeavor-content-query-section-list limit=3 section-alias="municipal/technologies/amr-ami" header="AMR/AMI" />
+          <endeavor-content-query-section-list
+            limit=3
+            section-alias="municipal/technologies/amr-ami"
+            header={ title: "AMR/AMI", href: "/municipal/technologies/amr-ami" }
+          />
         </div>
         <div class="col-lg-6 mb-block">
-          <endeavor-content-query-section-list limit=3 section-alias="municipal/technologies/aeration" header="Aeration" />
+          <endeavor-content-query-section-list
+            limit=3
+            section-alias="municipal/technologies/aeration"
+            header={ title: "Aeration", href: "/municipal/technologies/aeration" }
+          />
         </div>
         <div class="col-lg-6 mb-block">
-          <endeavor-content-query-section-list limit=3 section-alias="municipal/technologies/disinfection" header="Disinfection" />
+          <endeavor-content-query-section-list
+            limit=3
+            section-alias="municipal/technologies/disinfection"
+            header={ title: "Disinfection", href: "/municipal/technologies/disinfection" }
+          />
         </div>
         <div class="col-lg-6 mb-block">
-          <endeavor-content-query-section-list limit=3 section-alias="municipal/technologies/filtration" header="Filtration" />
+          <endeavor-content-query-section-list
+            limit=3
+            section-alias="municipal/technologies/filtration"
+            header={ title: "Filtration", href: "/municipal/technologies/filtration" }
+          />
         </div>
       </div>
     </div>
@@ -54,21 +70,41 @@ $ const adSlots = {
   </div>
   <div class="row">
     <div class="col-lg-8 mb-block">
-      <endeavor-content-query-section-list limit=3 section-alias="municipal/technologies/flow-level-pressure-measurement" header="Flow / Level / Pressure Measurement" />
+      <endeavor-content-query-section-list
+        limit=3
+        section-alias="municipal/technologies/flow-level-pressure-measurement"
+        header={ title: "Flow / Level / Pressure Measurement", href: "/municipal/technologies/flow-level-pressure-measurement" }
+      />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-content-query-section-list limit=3 section-alias="municipal/technologies/lab-sampling-analytical" header="Lab / Sampling / Analytical" />
+      <endeavor-content-query-section-list
+        limit=3
+        section-alias="municipal/technologies/lab-sampling-analytical"
+        header={ title: "Lab / Sampling / Analytical", href: "/municipal/technologies/lab-sampling-analytical" }
+      />
     </div>
   </div>
   <div class="row">
     <div class="col-lg-4 mb-block">
-      <endeavor-content-query-section-list limit=3 section-alias="municipal/technologies/pipes" header="Pipes" />
+      <endeavor-content-query-section-list
+        limit=3
+        section-alias="municipal/technologies/pipes"
+        header={ title: "Pipes", href: "/municipal/technologies/pipes" }
+      />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-content-query-section-list limit=3 section-alias="municipal/technologies/pumps" header="Pumps" />
+      <endeavor-content-query-section-list
+        limit=3
+        section-alias="municipal/technologies/pumps"
+        header={ title: "Pumps", href: "/municipal/technologies/pumps" }
+      />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-content-query-section-list limit=3 section-alias="municipal/technologies/valves" header="Valves" />
+      <endeavor-content-query-section-list
+        limit=3
+        section-alias="municipal/technologies/valves"
+        header={ title: "Valves", href: "/municipal/technologies/valves" }
+      />
     </div>
   </div>
 

--- a/sites/waterworld/server/templates/website-section/municipal.marko
+++ b/sites/waterworld/server/templates/website-section/municipal.marko
@@ -34,10 +34,19 @@ $ const adSlots = {
 
   <div class="row">
     <div class="col-lg-4 mb-block">
-      <endeavor-content-query-section-list section-alias="municipal/drinking-water" header="Drinking Water" />
+      <endeavor-content-query-section-list
+        section-alias="municipal/drinking-water"
+        header={ title: "Drinking Water", href: "/municipal/drinking-water" }
+        limit=6
+      />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue publication-id="5ca26a8b08cf3add038b45b7" header="WaterWorld" as-card=true content-count=0 />
+      <endeavor-magazine-query-latest-issue
+        publication-id="5ca26a8b08cf3add038b45b7"
+        header="WaterWorld"
+        as-card=true
+        content-count=2
+      />
     </div>
     <div class="col-lg-4 ad-rail">
       <endeavor-gam-ad-unit-display id="gpt-ad-rail1" />
@@ -47,19 +56,33 @@ $ const adSlots = {
 
   <div class="row">
     <div class="col-lg-4 mb-block">
-      <endeavor-content-query-section-list horizontal=true section-alias="municipal/drinking-water" header="Drinking Water" />
+      <endeavor-content-query-section-list
+        section-alias="municipal/drinking-water"
+        header={ title: "Drinking Water", href: "/municipal/drinking-water" }
+      />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-content-query-section-list horizontal=true section-alias="municipal/wastewater" header="Wastewater" />
+      <endeavor-content-query-section-list
+        section-alias="municipal/wastewater"
+        header={ title: "Wastewater", href: "/municipal/wastewater" }
+      />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-content-query-section-list limit=4 section-alias="municipal/urban-stormwater" header="Urban Stormwater" />
+      <endeavor-content-query-section-list
+        limit=4
+        section-alias="municipal/urban-stormwater"
+        header={ title: "Urban Stormwater", href: "/municipal/urban-stormwater" }
+      />
     </div>
   </div>
 
   <div class="row">
     <div class="col-lg-4 mb-block">
-      <endeavor-content-query-section-list limit=4 section-alias="municipal/environmental" header="Environmental" />
+      <endeavor-content-query-section-list
+        limit=4
+        section-alias="municipal/environmental"
+        header={ title: "Environmental", href: "/municipal/environmental" }
+      />
     </div>
     <div class="col-lg-4 mb-block">
       <endeavor-gam-ad-unit-define-display name="rail2" aliases=aliases />
@@ -70,7 +93,7 @@ $ const adSlots = {
           contentTypes: ["Video"],
           limit: 4,
         }
-        header="Videos"
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
   </div>


### PR DESCRIPTION
The `<endeavor-content-query-section-list>` and `<theme-pennwell-published-content-query-list>` components now accept a `header` object attribute that supports `title` and `href`. If `href` is set, the header links to the provided value. For example:

```marko
<endeavor-content-query-section-list
  limit=4
  section-alias="clinical"
  header={ title: "Clinical", href: "/clinical" }
  native-x={ placement: 'list1', aliases: ['clinical'], index: 3 }
/>
```

```marko
<theme-pennwell-published-content-query-list
  query={
    requiresImage: false,
    contentTypes: ["Video"],
    limit: 3,
  }
  header={ title: "Videos", href: "/videos" }
/>
```

The `<endeavor-magazine-query-latest-issue>` still accepts `header` as a string, but will now automatically link to the current issue returned from the query. As such, this call did not change:
```marko
<endeavor-magazine-query-latest-issue
  publication-id="5c9a271747062ba1048b4569"
  header="Current Issue"
/>
```