### PR TITLE
Set navbar z-index

### DIFF
--- a/packages/themes/pennwell/styles/components/_navbars.scss
+++ b/packages/themes/pennwell/styles/components/_navbars.scss
@@ -178,7 +178,7 @@
   position: fixed;
   top: 120px;
   bottom: 0;
-  z-index: 100;
+  z-index: 5000000;
 
   width: $wrapper-width;
   max-width: $wrapper-max-width;

--- a/packages/themes/pennwell/styles/components/_navbars.scss
+++ b/packages/themes/pennwell/styles/components/_navbars.scss
@@ -2,7 +2,7 @@
   position: fixed;
   right: 0;
   left: 0;
-  z-index: 1030;
+  z-index: 5000000;
   font-family: $theme-content-sans-serif-font;
   box-shadow: $theme-box-shadow-lg;
   opacity: .98;


### PR DESCRIPTION
Per IAB spec, navbars should be z-indexed at 5M to prevent display ads from overlaying them: https://www.iab.com/wp-content/uploads/2017/07/IABNewAdPortfolio_Quick_Guide_2017-07.xlsx Ref https://southcomm.atlassian.net/browse/CS-2060