### PR TITLE
Analysts support for SU; home page layout for LFW

### DIFF
--- a/packages/themes/pennwell/api/fragments/website-section-page.js
+++ b/packages/themes/pennwell/api/fragments/website-section-page.js
@@ -2,9 +2,12 @@ const gql = require('graphql-tag');
 
 module.exports = gql`
 fragment WebsiteSectionPageFragment on WebsiteSection {
+  name
+  description
   hierarchy {
     id
     alias
+    name
   }
 }
 `;

--- a/sites/laserfocusworld/server/templates/index.marko
+++ b/sites/laserfocusworld/server/templates/index.marko
@@ -34,14 +34,44 @@ $ const adSlots = {
 
   <div class="row">
     <div class="col-lg-8">
-      <endeavor-content-query-feed
-        header="Featured"
-        limit=7
-        skip=5
-        section-id=section.id
-        native-x={ placement: 'list2', aliases, index: 6 }
-      />
+      <div class="row">
+        <div class="col-lg-6 mb-block">
+          <endeavor-content-query-section-list
+            limit=3
+            section-alias="detectors-imaging"
+            header={ title: "Detectors & Imaging", href: "/detectors-imaging" }
+            native-x={ placement: 'list1', aliases: ['detectors-imaging'], index: 3 }
+          />
+        </div>
+        <div class="col-lg-6 mb-block">
+          <endeavor-content-query-section-list
+            limit=3
+            section-alias="lasers-sources"
+            header={ title: "Lasers & Sources", href: "/lasers-sources" }
+            native-x={ placement: 'list1', aliases: ['lasers-sources'], index: 3 }
+          />
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-lg-6 mb-block">
+          <endeavor-content-query-section-list
+            limit=3
+            section-alias="optics"
+            header={ title: "Optics", href: "/optics" }
+            native-x={ placement: 'list1', aliases: ['optics'], index: 2 }
+          />
+        </div>
+        <div class="col-lg-6 mb-block">
+          <endeavor-content-query-section-list
+            limit=3
+            section-alias="software-accessories"
+            header={ title: "Software Accessories", href: "/software-accessories" }
+            native-x={ placement: 'list1', aliases: ['software-accessories'], index: 2 }
+          />
+        </div>
+      </div>
     </div>
+
     <div class="col-lg-4 ad-rail">
       <endeavor-gam-ad-unit-display id="gpt-ad-rail1" />
       <endeavor-gam-ad-unit-display id="gpt-ad-rail2" />
@@ -50,12 +80,20 @@ $ const adSlots = {
 
   <div class="row">
     <div class="col-lg-4 mb-block">
+      <endeavor-content-query-section-list
+        limit=3
+        section-alias="test-measurement"
+        header={ title: "Test & Measurement", href: "/test-measurement" }
+        native-x={ placement: 'list1', aliases: ['test-measurement'], index: 2 }
+      />
+    </div>
+    <div class="col-lg-4 mb-block">
       <theme-pennwell-published-content-query-list
         query={
-          contentTypes: ["Video"],
-          limit: 4,
+          contentTypes: ["Webinar"],
+          limit: 3,
         }
-        header={ title: "Videos", href: "/videos" }
+        header={ title: "Webcasts", href: "/webcasts" }
       />
     </div>
     <div class="col-lg-4 mb-block">
@@ -63,14 +101,39 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Whitepaper"],
-          limit: 4,
+          limit: 3,
         }
         with-image=false
         header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
+  </div>
+
+  <div class="row">
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue publication-id="5ca4e38b75a25490050041a9" header="Current Issue" />
+      <theme-pennwell-published-content-query-list
+        query={
+          contentTypes: ["Video"],
+          limit: 5,
+        }
+        header={ title: "Videos", href: "/videos" }
+      />
+    </div>
+    <div class="col-lg-4 mb-block">
+      <endeavor-content-query-feed
+        header="More from LaserFocusWorld"
+        limit=7
+        skip=5
+        section-id=section.id
+      />
+    </div>
+    <div class="col-lg-4 mb-block">
+      <endeavor-magazine-query-latest-issue
+        publication-id="5ca4e38b75a25490050041a9"
+        header="Current Issue"
+        as-card=true
+        content-count=0
+      />
     </div>
   </div>
 

--- a/sites/ledsmagazine/config/site.js
+++ b/sites/ledsmagazine/config/site.js
@@ -48,6 +48,7 @@ module.exports = {
   menuItems: {
     resources: [
       { href: '/magazine', label: 'Magazine' },
+      { href: '/blogs', label: 'Blogs' },
       { href: '/videos', label: 'Videos' },
       { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },

--- a/sites/offshore-mag/server/templates/index.marko
+++ b/sites/offshore-mag/server/templates/index.marko
@@ -157,6 +157,7 @@ $ const adSlots = {
         publication-id="5ca78e0e75a2541f0e0041a9"
         header="Current Issue"
         as-card=true
+        content-limit=0
       />
     </div>
   </div>

--- a/sites/strategies-u/server/routes/website-section.js
+++ b/sites/strategies-u/server/routes/website-section.js
@@ -1,8 +1,13 @@
 const queryFragment = require('@endeavorb2b/base-website-themes/pennwell/api/fragments/website-section-page');
 const { withWebsiteSection } = require('@base-cms/marko-web/middleware');
 const section = require('../templates/website-section');
+const analystsTemplate = require('../templates/contact-us');
 
 module.exports = (app) => {
+  app.get('/:alias(analysts)', withWebsiteSection({
+    template: analystsTemplate,
+    queryFragment,
+  }));
   app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
     template: section,
     queryFragment,

--- a/sites/strategies-u/server/templates/contact-us/index.marko
+++ b/sites/strategies-u/server/templates/contact-us/index.marko
@@ -4,7 +4,7 @@ import contentListFragment from '@endeavorb2b/base-website-common/api/fragments/
 $ const { site } = out.global;
 $ const section = getAsObject(data, 'section');
 $ const query = {
-  sectionAlias: 'contact-us',
+  sectionAlias: section.alias,
   limit: 100,
   queryFragment: contentListFragment,
 };
@@ -25,9 +25,9 @@ $ const query = {
     <div class="row">
       <div class="col">
         <div class="page-wrapper__header">
-          <endeavor-breadcrumbs-contact-us />
+          <endeavor-breadcrumbs-website-section section=section />
           <div class="page-wrapper__title">
-            Contact Us
+            ${section.name}
           </div>
         </div>
         <div class="page-wrapper__body">


### PR DESCRIPTION
Also made the contact us page layout more universally usable based on section name/alias (re-used for Analysts)