### PR TITLE
Add company and author load more; apply to all content pages

### DIFF
--- a/packages/common/components/content/blocks/marko.json
+++ b/packages/common/components/content/blocks/marko.json
@@ -146,6 +146,9 @@
     "endeavor-content-query-load-more-author": {
       "template": "./query-load-more-author.marko"
     },
+    "endeavor-content-query-load-more-company": {
+      "template": "./query-load-more-company.marko"
+    },
     "endeavor-content-query-load-more-list": {
       "template": "./query-load-more-list.marko"
     },

--- a/packages/common/components/content/blocks/marko.json
+++ b/packages/common/components/content/blocks/marko.json
@@ -143,6 +143,9 @@
     "endeavor-content-query-load-more": {
       "template": "./query-load-more.marko"
     },
+    "endeavor-content-query-load-more-author": {
+      "template": "./query-load-more-author.marko"
+    },
     "endeavor-content-query-load-more-list": {
       "template": "./query-load-more-list.marko"
     },

--- a/packages/common/components/content/blocks/query-load-more-author.marko
+++ b/packages/common/components/content/blocks/query-load-more-author.marko
@@ -35,6 +35,11 @@ $ const imageOptions = { w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0
   $ const cardNodes = asArray(nodes.slice(0, 10));
   $ const listNodes = asArray(nodes.slice(10));
   <if(cardNodes.length || listNodes.length)>
+    <if(input.header && pageNumber === 1)>
+      <endeavor-load-more-header>
+        ${input.header}
+      </endeavor-load-more-header>
+    </if>
     <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
     <div class=block>
       <if(cardNodes.length)>

--- a/packages/common/components/content/blocks/query-load-more-author.marko
+++ b/packages/common/components/content/blocks/query-load-more-author.marko
@@ -1,0 +1,108 @@
+import { getAsObject, getAsArray } from '@base-cms/object-path';
+import { asArray, asObject } from '@base-cms/utils';
+import contentListFragment from '../../../api/fragments/content-list';
+
+$ const { site } = out.global;
+$ const pageNumber = input.pageNumber || 1;
+$ const block = 'content-query-load-more';
+$ const query = {
+  limit: 15,
+  ...input.query,
+  queryFragment: contentListFragment,
+  queryName: 'QueryLoadMore',
+};
+
+$ const loadMore = {
+  ...input.loadMore,
+};
+
+$ const adAliases = getAsArray(input, 'ads.aliases');
+$ const adCardInput = {
+  name: 'load-more',
+  size: [300, 250],
+  modifiers: ['in-card'],
+  ...getAsObject(input, 'ads.card'),
+};
+$ const adListInput = {
+  name: 'load-more',
+  size: [300, 600],
+  modifiers: ['in-card'],
+  ...getAsObject(input, 'ads.list'),
+};
+$ const imageOptions = { w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0.5, fpY: 0.5 };
+
+<cms-query-all-author-content|{ nodes, pageInfo }| ...query>
+  $ const cardNodes = asArray(nodes.slice(0, 10));
+  $ const listNodes = asArray(nodes.slice(10));
+  <if(cardNodes.length || listNodes.length)>
+    <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
+    <div class=block>
+      <if(cardNodes.length)>
+        <div class="row">
+          <for|content, index| of=cardNodes>
+            <div class=`${block}__col`>
+              <endeavor-content-block-item
+                content=content
+                image-modifiers=["fluid", "21by9"]
+                image-options=imageOptions
+                image-position="top"
+                modifiers=["card"]
+              />
+            </div>
+            <if(index === 1 || index === 6)>
+              <div class=`${block}__col`>
+                <endeavor-gam-ad-unit-define-display ...adCardInput aliases=adAliases />
+              </div>
+            </if>
+          </for>
+        </div>
+      </if>
+
+      <if(listNodes.length)>
+        <div class="row">
+          <div class=`${block}__col-ad`>
+            <endeavor-gam-ad-unit-define-display ...adListInput aliases=adAliases />
+          </div>
+
+          <div class=`${block}__col-list`>
+            <endeavor-item-list flush=true card=true items=listNodes>
+              <@item|{ item }|>
+                <endeavor-content-block-item
+                  content=item
+                  image-position="left"
+                  image-options={ w: 176, h: 99, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
+                  image-width=176
+                  image-height=99
+                />
+              </@item>
+            </endeavor-item-list>
+          </div>
+        </div>
+      </if>
+    </div>
+    $ const { endCursor, hasNextPage } = pageInfo;
+    $ delete query.skip;
+    $ delete query.queryFragment;
+    $ delete query.renderBody;
+    $ query.after = endCursor;
+    $ const provide = {
+      ...input,
+      query,
+      ads: {
+        aliases: adAliases,
+        card: adCardInput,
+        list: adListInput,
+      },
+    };
+
+    <endeavor-load-more-button
+      append-to=".container-fluid-max"
+      block-name="content-query-load-more-author"
+      label="Load More Content"
+      max-pages=loadMore.maxPages
+      page-number=pageNumber
+      provide=provide
+      show=hasNextPage
+    />
+  </if>
+</cms-query-all-author-content>

--- a/packages/common/components/content/blocks/query-load-more-company.marko
+++ b/packages/common/components/content/blocks/query-load-more-company.marko
@@ -35,6 +35,11 @@ $ const imageOptions = { w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0
   $ const cardNodes = asArray(nodes.slice(0, 10));
   $ const listNodes = asArray(nodes.slice(10));
   <if(cardNodes.length || listNodes.length)>
+    <if(input.header && pageNumber === 1)>
+      <endeavor-load-more-header>
+        ${input.header}
+      </endeavor-load-more-header>
+    </if>
     <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
     <div class=block>
       <if(cardNodes.length)>

--- a/packages/common/components/content/blocks/query-load-more-company.marko
+++ b/packages/common/components/content/blocks/query-load-more-company.marko
@@ -1,0 +1,108 @@
+import { getAsObject, getAsArray } from '@base-cms/object-path';
+import { asArray, asObject } from '@base-cms/utils';
+import contentListFragment from '../../../api/fragments/content-list';
+
+$ const { site } = out.global;
+$ const pageNumber = input.pageNumber || 1;
+$ const block = 'content-query-load-more';
+$ const query = {
+  limit: 15,
+  ...input.query,
+  queryFragment: contentListFragment,
+  queryName: 'QueryLoadMore',
+};
+
+$ const loadMore = {
+  ...input.loadMore,
+};
+
+$ const adAliases = getAsArray(input, 'ads.aliases');
+$ const adCardInput = {
+  name: 'load-more',
+  size: [300, 250],
+  modifiers: ['in-card'],
+  ...getAsObject(input, 'ads.card'),
+};
+$ const adListInput = {
+  name: 'load-more',
+  size: [300, 600],
+  modifiers: ['in-card'],
+  ...getAsObject(input, 'ads.list'),
+};
+$ const imageOptions = { w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0.5, fpY: 0.5 };
+
+<cms-query-all-company-content|{ nodes, pageInfo }| ...query>
+  $ const cardNodes = asArray(nodes.slice(0, 10));
+  $ const listNodes = asArray(nodes.slice(10));
+  <if(cardNodes.length || listNodes.length)>
+    <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
+    <div class=block>
+      <if(cardNodes.length)>
+        <div class="row">
+          <for|content, index| of=cardNodes>
+            <div class=`${block}__col`>
+              <endeavor-content-block-item
+                content=content
+                image-modifiers=["fluid", "21by9"]
+                image-options=imageOptions
+                image-position="top"
+                modifiers=["card"]
+              />
+            </div>
+            <if(index === 1 || index === 6)>
+              <div class=`${block}__col`>
+                <endeavor-gam-ad-unit-define-display ...adCardInput aliases=adAliases />
+              </div>
+            </if>
+          </for>
+        </div>
+      </if>
+
+      <if(listNodes.length)>
+        <div class="row">
+          <div class=`${block}__col-ad`>
+            <endeavor-gam-ad-unit-define-display ...adListInput aliases=adAliases />
+          </div>
+
+          <div class=`${block}__col-list`>
+            <endeavor-item-list flush=true card=true items=listNodes>
+              <@item|{ item }|>
+                <endeavor-content-block-item
+                  content=item
+                  image-position="left"
+                  image-options={ w: 176, h: 99, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
+                  image-width=176
+                  image-height=99
+                />
+              </@item>
+            </endeavor-item-list>
+          </div>
+        </div>
+      </if>
+    </div>
+    $ const { endCursor, hasNextPage } = pageInfo;
+    $ delete query.skip;
+    $ delete query.queryFragment;
+    $ delete query.renderBody;
+    $ query.after = endCursor;
+    $ const provide = {
+      ...input,
+      query,
+      ads: {
+        aliases: adAliases,
+        card: adCardInput,
+        list: adListInput,
+      },
+    };
+
+    <endeavor-load-more-button
+      append-to=".container-fluid-max"
+      block-name="content-query-load-more-company"
+      label="Load More Content"
+      max-pages=loadMore.maxPages
+      page-number=pageNumber
+      provide=provide
+      show=hasNextPage
+    />
+  </if>
+</cms-query-all-company-content>

--- a/packages/common/components/content/blocks/query-load-more.marko
+++ b/packages/common/components/content/blocks/query-load-more.marko
@@ -1,6 +1,5 @@
 import { getAsObject, getAsArray } from '@base-cms/object-path';
 import { asArray, asObject } from '@base-cms/utils';
-import { buildImgixUrl } from '@base-cms/image';
 import contentListFragment from '../../../api/fragments/content-list';
 import { useNativeX } from '../../../services/native-x';
 

--- a/packages/common/components/content/blocks/query-load-more.marko
+++ b/packages/common/components/content/blocks/query-load-more.marko
@@ -42,6 +42,11 @@ $ const imageOptions = { w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0
   $ const cardNodes = asArray(nodes.slice(0, 10));
   $ const listNodes = asArray(nodes.slice(10));
   <if(cardNodes.length || listNodes.length)>
+    <if(input.header && pageNumber === 1)>
+      <endeavor-load-more-header>
+        ${input.header}
+      </endeavor-load-more-header>
+    </if>
     <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
     <div class=block>
       <if(cardNodes.length)>

--- a/sites/aquamagazine/server/routes/load-more.js
+++ b/sites/aquamagazine/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/aquamagazine/server/templates/content/index.marko
+++ b/sites/aquamagazine/server/templates/content/index.marko
@@ -39,11 +39,13 @@ $ const adSlots = {
 
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-        />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/aquamagazine/server/templates/content/index.marko
+++ b/sites/aquamagazine/server/templates/content/index.marko
@@ -51,11 +51,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -63,6 +75,6 @@ $ const adSlots = {
         }
         ads={ aliases }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/athleticbusiness/server/routes/load-more.js
+++ b/sites/athleticbusiness/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/athleticbusiness/server/templates/content/index.marko
+++ b/sites/athleticbusiness/server/templates/content/index.marko
@@ -39,11 +39,13 @@ $ const adSlots = {
 
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-        />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/athleticbusiness/server/templates/content/index.marko
+++ b/sites/athleticbusiness/server/templates/content/index.marko
@@ -51,11 +51,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -63,6 +75,6 @@ $ const adSlots = {
         }
         ads={ aliases }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/automationworld/server/routes/load-more.js
+++ b/sites/automationworld/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/automationworld/server/templates/content/index.marko
+++ b/sites/automationworld/server/templates/content/index.marko
@@ -39,11 +39,13 @@ $ const adSlots = {
 
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-        />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/automationworld/server/templates/content/index.marko
+++ b/sites/automationworld/server/templates/content/index.marko
@@ -51,11 +51,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -63,6 +75,6 @@ $ const adSlots = {
         }
         ads={ aliases }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/bioopticsworld/server/routes/load-more.js
+++ b/sites/bioopticsworld/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/bioopticsworld/server/templates/content/index.marko
+++ b/sites/bioopticsworld/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -65,6 +77,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/bioopticsworld/server/templates/content/index.marko
+++ b/sites/bioopticsworld/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/broadbandtechreport/server/routes/load-more.js
+++ b/sites/broadbandtechreport/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/broadbandtechreport/server/templates/content/index.marko
+++ b/sites/broadbandtechreport/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -65,6 +77,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/broadbandtechreport/server/templates/content/index.marko
+++ b/sites/broadbandtechreport/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/cablinginstall/server/routes/load-more.js
+++ b/sites/cablinginstall/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/cablinginstall/server/templates/content/index.marko
+++ b/sites/cablinginstall/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -65,6 +77,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/cablinginstall/server/templates/content/index.marko
+++ b/sites/cablinginstall/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/dentaleconomics/server/routes/load-more.js
+++ b/sites/dentaleconomics/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/dentaleconomics/server/templates/content/index.marko
+++ b/sites/dentaleconomics/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/dentaleconomics/server/templates/content/index.marko
+++ b/sites/dentaleconomics/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           limit: 10,
           skip: 5,
@@ -66,6 +78,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/dentistryiq/server/routes/load-more.js
+++ b/sites/dentistryiq/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/dentistryiq/server/templates/content/index.marko
+++ b/sites/dentistryiq/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/dentistryiq/server/templates/content/index.marko
+++ b/sites/dentistryiq/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           limit: 10,
           skip: 5,
@@ -66,6 +78,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/evaluationengineering/server/routes/load-more.js
+++ b/sites/evaluationengineering/server/routes/load-more.js
@@ -1,5 +1,8 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
+const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
 const magazineIssues = require('@endeavorb2b/base-website-common/components/magazine/blocks/query-active-issues');
@@ -7,6 +10,9 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
+  'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,
   'magazine-active-issues': magazineIssues,

--- a/sites/evaluationengineering/server/templates/content/index.marko
+++ b/sites/evaluationengineering/server/templates/content/index.marko
@@ -50,11 +50,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -66,6 +78,7 @@ $ const adSlots = {
           card: { name: "HP" },
         }
       />
-    </if>
+    </else-if>
   </@below-container>
+</theme-pennwell-content-layout>
 </theme-pennwell-content-layout>

--- a/sites/evaluationengineering/server/templates/content/index.marko
+++ b/sites/evaluationengineering/server/templates/content/index.marko
@@ -37,10 +37,14 @@ $ const adSlots = {
       </div>
 
       <aside class="col-lg-4">
-        <!-- Displaying ad unit 2 before 1 is intentional -->
-        <endeavor-gam-ad-unit-display id="gpt-ad-right2" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-right1" modifiers=["content-page-right"] />
-        <endeavor-content-query-related exclude-content-ids=[content.id] section-id=section.id />
+        <endeavor-gam-ad-unit-display id="gpt-ad-right2" modifiers=["content-page-right"] />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/healthcarepackaging/server/routes/load-more.js
+++ b/sites/healthcarepackaging/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/healthcarepackaging/server/templates/content/index.marko
+++ b/sites/healthcarepackaging/server/templates/content/index.marko
@@ -39,11 +39,13 @@ $ const adSlots = {
 
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-        />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/healthcarepackaging/server/templates/content/index.marko
+++ b/sites/healthcarepackaging/server/templates/content/index.marko
@@ -51,11 +51,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -63,6 +75,6 @@ $ const adSlots = {
         }
         ads={ aliases }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/industrial-lasers/server/routes/load-more.js
+++ b/sites/industrial-lasers/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/industrial-lasers/server/templates/content/index.marko
+++ b/sites/industrial-lasers/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -65,6 +77,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/industrial-lasers/server/templates/content/index.marko
+++ b/sites/industrial-lasers/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/intelligent-aerospace/server/routes/load-more.js
+++ b/sites/intelligent-aerospace/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/intelligent-aerospace/server/templates/content/index.marko
+++ b/sites/intelligent-aerospace/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -65,6 +77,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/intelligent-aerospace/server/templates/content/index.marko
+++ b/sites/intelligent-aerospace/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/laserfocusworld/server/routes/load-more.js
+++ b/sites/laserfocusworld/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/laserfocusworld/server/templates/content/index.marko
+++ b/sites/laserfocusworld/server/templates/content/index.marko
@@ -40,21 +40,35 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -63,6 +77,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/ledsmagazine/server/routes/load-more.js
+++ b/sites/ledsmagazine/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/ledsmagazine/server/templates/content/index.marko
+++ b/sites/ledsmagazine/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -65,6 +77,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/ledsmagazine/server/templates/content/index.marko
+++ b/sites/ledsmagazine/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/lightwaveonline/server/routes/load-more.js
+++ b/sites/lightwaveonline/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/lightwaveonline/server/templates/content/index.marko
+++ b/sites/lightwaveonline/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -65,6 +77,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/lightwaveonline/server/templates/content/index.marko
+++ b/sites/lightwaveonline/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/militaryaerospace/server/routes/load-more.js
+++ b/sites/militaryaerospace/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/militaryaerospace/server/templates/content/index.marko
+++ b/sites/militaryaerospace/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -65,6 +77,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/militaryaerospace/server/templates/content/index.marko
+++ b/sites/militaryaerospace/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/oemmagazine/server/routes/load-more.js
+++ b/sites/oemmagazine/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/oemmagazine/server/templates/content/index.marko
+++ b/sites/oemmagazine/server/templates/content/index.marko
@@ -39,11 +39,13 @@ $ const adSlots = {
 
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-        />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/oemmagazine/server/templates/content/index.marko
+++ b/sites/oemmagazine/server/templates/content/index.marko
@@ -51,11 +51,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -63,6 +75,6 @@ $ const adSlots = {
         }
         ads={ aliases }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/officer/server/routes/load-more.js
+++ b/sites/officer/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/officer/server/templates/content/index.marko
+++ b/sites/officer/server/templates/content/index.marko
@@ -50,11 +50,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -66,6 +78,7 @@ $ const adSlots = {
           card: { name: "HP" },
         }
       />
-    </if>
+    </else-if>
   </@below-container>
+</theme-pennwell-content-layout>
 </theme-pennwell-content-layout>

--- a/sites/officer/server/templates/content/index.marko
+++ b/sites/officer/server/templates/content/index.marko
@@ -37,10 +37,14 @@ $ const adSlots = {
       </div>
 
       <aside class="col-lg-4">
-        <!-- Displaying ad unit 2 before 1 is intentional -->
-        <endeavor-gam-ad-unit-display id="gpt-ad-right2" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-right1" modifiers=["content-page-right"] />
-        <endeavor-content-query-related exclude-content-ids=[content.id] section-id=section.id />
+        <endeavor-gam-ad-unit-display id="gpt-ad-right2" modifiers=["content-page-right"] />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/offshore-mag/server/routes/load-more.js
+++ b/sites/offshore-mag/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/offshore-mag/server/templates/content/index.marko
+++ b/sites/offshore-mag/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -65,6 +77,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/offshore-mag/server/templates/content/index.marko
+++ b/sites/offshore-mag/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/ogj/server/routes/load-more.js
+++ b/sites/ogj/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/ogj/server/templates/content/index.marko
+++ b/sites/ogj/server/templates/content/index.marko
@@ -39,11 +39,13 @@ $ const adSlots = {
 
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-        />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/ogj/server/templates/content/index.marko
+++ b/sites/ogj/server/templates/content/index.marko
@@ -51,11 +51,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -63,6 +75,6 @@ $ const adSlots = {
         }
         ads={ aliases }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/packworld/server/routes/load-more.js
+++ b/sites/packworld/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/packworld/server/templates/content/index.marko
+++ b/sites/packworld/server/templates/content/index.marko
@@ -39,11 +39,13 @@ $ const adSlots = {
 
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-        />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/packworld/server/templates/content/index.marko
+++ b/sites/packworld/server/templates/content/index.marko
@@ -51,11 +51,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -63,6 +75,6 @@ $ const adSlots = {
         }
         ads={ aliases }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/perioimplantadvisory/server/routes/load-more.js
+++ b/sites/perioimplantadvisory/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/perioimplantadvisory/server/templates/content/index.marko
+++ b/sites/perioimplantadvisory/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/perioimplantadvisory/server/templates/content/index.marko
+++ b/sites/perioimplantadvisory/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           limit: 10,
           skip: 5,
@@ -66,6 +78,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/plasticsmachinerymagazine/server/routes/load-more.js
+++ b/sites/plasticsmachinerymagazine/server/routes/load-more.js
@@ -1,5 +1,8 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
+const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
 const magazineIssues = require('@endeavorb2b/base-website-common/components/magazine/blocks/query-active-issues');
@@ -7,6 +10,9 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
+  'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,
   'magazine-active-issues': magazineIssues,

--- a/sites/plasticsmachinerymagazine/server/templates/content/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/content/index.marko
@@ -50,11 +50,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -66,6 +78,7 @@ $ const adSlots = {
           card: { name: "HP" },
         }
       />
-    </if>
+    </else-if>
   </@below-container>
+</theme-pennwell-content-layout>
 </theme-pennwell-content-layout>

--- a/sites/plasticsmachinerymagazine/server/templates/content/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/content/index.marko
@@ -37,10 +37,14 @@ $ const adSlots = {
       </div>
 
       <aside class="col-lg-4">
-        <!-- Displaying ad unit 2 before 1 is intentional -->
-        <endeavor-gam-ad-unit-display id="gpt-ad-right2" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-right1" modifiers=["content-page-right"] />
-        <endeavor-content-query-related exclude-content-ids=[content.id] section-id=section.id />
+        <endeavor-gam-ad-unit-display id="gpt-ad-right2" modifiers=["content-page-right"] />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/profoodworld/server/routes/load-more.js
+++ b/sites/profoodworld/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/profoodworld/server/templates/content/index.marko
+++ b/sites/profoodworld/server/templates/content/index.marko
@@ -39,11 +39,13 @@ $ const adSlots = {
 
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-        />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/profoodworld/server/templates/content/index.marko
+++ b/sites/profoodworld/server/templates/content/index.marko
@@ -51,11 +51,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -63,6 +75,6 @@ $ const adSlots = {
         }
         ads={ aliases }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/rdhmag/server/routes/load-more.js
+++ b/sites/rdhmag/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/rdhmag/server/templates/content/index.marko
+++ b/sites/rdhmag/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/rdhmag/server/templates/content/index.marko
+++ b/sites/rdhmag/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           limit: 10,
           skip: 5,
@@ -66,6 +78,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/strategies-u/server/routes/load-more.js
+++ b/sites/strategies-u/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/strategies-u/server/templates/content/index.marko
+++ b/sites/strategies-u/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -65,6 +77,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/strategies-u/server/templates/content/index.marko
+++ b/sites/strategies-u/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/utilityproducts/server/routes/load-more.js
+++ b/sites/utilityproducts/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/utilityproducts/server/templates/content/index.marko
+++ b/sites/utilityproducts/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -65,6 +77,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/utilityproducts/server/templates/content/index.marko
+++ b/sites/utilityproducts/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/vision-systems/server/routes/load-more.js
+++ b/sites/vision-systems/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/vision-systems/server/templates/content/index.marko
+++ b/sites/vision-systems/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -65,6 +77,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/vision-systems/server/templates/content/index.marko
+++ b/sites/vision-systems/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/waterworld/server/routes/load-more.js
+++ b/sites/waterworld/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/waterworld/server/templates/content/index.marko
+++ b/sites/waterworld/server/templates/content/index.marko
@@ -52,11 +52,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -65,6 +77,6 @@ $ const adSlots = {
         ads={ aliases }
         native-x={ placement: 'card', aliases, index: 0 }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>

--- a/sites/waterworld/server/templates/content/index.marko
+++ b/sites/waterworld/server/templates/content/index.marko
@@ -40,11 +40,13 @@ $ const adSlots = {
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-          native-x={ placement: 'list1', aliases, index: 4 }
-        />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+            native-x={ placement: 'list1', aliases, index: 4 }
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/woodfloorbusiness/server/routes/load-more.js
+++ b/sites/woodfloorbusiness/server/routes/load-more.js
@@ -1,5 +1,7 @@
 const { withLoadMore } = require('@base-cms/marko-web/middleware');
 const contentLoadMore = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more');
+const contentLoadMoreAuthor = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-author');
+const contentLoadMoreCompany = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-company');
 const contentLoadMoreList = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-list');
 const publishedLoadMore = require('@endeavorb2b/base-website-themes/pennwell/components/published-content/query-load-more');
 const magazineIssueContent = require('@endeavorb2b/base-website-common/components/content/blocks/query-load-more-issue-content');
@@ -8,6 +10,8 @@ const magazineIssues = require('@endeavorb2b/base-website-common/components/maga
 // Register blocks that support load more...
 const blocks = {
   'content-query-load-more': contentLoadMore,
+  'content-query-load-more-author': contentLoadMoreAuthor,
+  'content-query-load-more-company': contentLoadMoreCompany,
   'content-query-load-more-list': contentLoadMoreList,
   'published-content-query-load-more': publishedLoadMore,
   'magazine-query-issue-content': magazineIssueContent,

--- a/sites/woodfloorbusiness/server/templates/content/index.marko
+++ b/sites/woodfloorbusiness/server/templates/content/index.marko
@@ -39,11 +39,13 @@ $ const adSlots = {
 
       <aside class="col-lg-4">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
-        <endeavor-content-query-related
-          exclude-content-ids=[content.id]
-          section-id=section.id
-        />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
+        <if(!['contact', 'company'].includes(content.type))>
+          <endeavor-content-query-related
+            exclude-content-ids=[content.id]
+            section-id=section.id
+          />
+        </if>
       </aside>
     </div>
   </div>

--- a/sites/woodfloorbusiness/server/templates/content/index.marko
+++ b/sites/woodfloorbusiness/server/templates/content/index.marko
@@ -51,11 +51,23 @@ $ const adSlots = {
   </div>
 
   <@below-container>
-    <if(section.id)>
-      <endeavor-load-more-header>
-        More in ${section.name}
-      </endeavor-load-more-header>
+    <if(content.type === 'contact')>
+      <endeavor-content-query-load-more-author
+        header=`More from ${content.name}`
+        query={ contactId: content.id }
+        ads={ aliases }
+      />
+    </if>
+    <else-if(content.type === 'company')>
+      <endeavor-content-query-load-more-company
+        header=`More from ${content.name}`
+        query={ companyId: content.id }
+        ads={ aliases }
+      />
+    </else-if>
+    <else-if(section.id)>
       <endeavor-content-query-load-more
+        header=`More in ${section.name}`
         query={
           skip: 5,
           excludeContentIds: [content.id],
@@ -63,6 +75,6 @@ $ const adSlots = {
         }
         ads={ aliases }
       />
-    </if>
+    </else-if>
   </@below-container>
 </theme-pennwell-content-layout>


### PR DESCRIPTION
- Create `<endeavor-content-query-load-more-author>` component
- Create `<endeavor-content-query-load-more-company>` component
- Handle load more header within load more component
- Hide related content block on company and contact types
- Register author and company components within website load more routes
- Display author and company load more on all website content pages