### PR TITLE
Update Content ID routing

### DIFF
--- a/sites/aquamagazine/server/routes/content.js
+++ b/sites/aquamagazine/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/athleticbusiness/server/routes/content.js
+++ b/sites/athleticbusiness/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/automationworld/server/routes/content.js
+++ b/sites/automationworld/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/bioopticsworld/server/routes/content.js
+++ b/sites/bioopticsworld/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/broadbandtechreport/server/routes/content.js
+++ b/sites/broadbandtechreport/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/cablinginstall/server/routes/content.js
+++ b/sites/cablinginstall/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/clevescene/server/routes/content.js
+++ b/sites/clevescene/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/dentaleconomics/server/routes/content.js
+++ b/sites/dentaleconomics/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/dentistryiq/server/routes/content.js
+++ b/sites/dentistryiq/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/evaluationengineering/server/routes/content.js
+++ b/sites/evaluationengineering/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/healthcarepackaging/server/routes/content.js
+++ b/sites/healthcarepackaging/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/industrial-lasers/server/routes/content.js
+++ b/sites/industrial-lasers/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/intelligent-aerospace/server/routes/content.js
+++ b/sites/intelligent-aerospace/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/laserfocusworld/server/routes/content.js
+++ b/sites/laserfocusworld/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/ledsmagazine/server/routes/content.js
+++ b/sites/ledsmagazine/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/lightwaveonline/server/routes/content.js
+++ b/sites/lightwaveonline/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/metrotimes/server/routes/content.js
+++ b/sites/metrotimes/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/militaryaerospace/server/routes/content.js
+++ b/sites/militaryaerospace/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/oemmagazine/server/routes/content.js
+++ b/sites/oemmagazine/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/officer/server/routes/content.js
+++ b/sites/officer/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/offshore-mag/server/routes/content.js
+++ b/sites/offshore-mag/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/orlandoweekly/server/routes/content.js
+++ b/sites/orlandoweekly/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/outinsa/server/routes/content.js
+++ b/sites/outinsa/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/outinstl/server/routes/content.js
+++ b/sites/outinstl/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/packworld/server/routes/content.js
+++ b/sites/packworld/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/perioimplantadvisory/server/routes/content.js
+++ b/sites/perioimplantadvisory/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/plasticsmachinerymagazine/server/routes/content.js
+++ b/sites/plasticsmachinerymagazine/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/profoodworld/server/routes/content.js
+++ b/sites/profoodworld/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/rdhmag/server/routes/content.js
+++ b/sites/rdhmag/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/riverfronttimes/server/routes/content.js
+++ b/sites/riverfronttimes/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/sacurrent/server/routes/content.js
+++ b/sites/sacurrent/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/strategies-u/server/routes/content.js
+++ b/sites/strategies-u/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/utilityproducts/server/routes/content.js
+++ b/sites/utilityproducts/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/vision-systems/server/routes/content.js
+++ b/sites/vision-systems/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/waterworld/server/routes/content.js
+++ b/sites/waterworld/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/woodfloorbusiness/server/routes/content.js
+++ b/sites/woodfloorbusiness/server/routes/content.js
@@ -3,7 +3,7 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({
+  app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
   }));


### PR DESCRIPTION
Makes the content ID less greedy, allowing it to match `16651798` instead of `20010050` in `/test/article/16651798/spirent-communications-px3dx3-40020010050gbe-qsfpdd-appliance`.

Nifty tool https://forbeslindesay.github.io/express-route-tester/

Resolves [CS-2124](https://southcomm.atlassian.net/browse/CS-2144) @Jlaird 