### PR TITLE
Set common @base-cms as direct dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 node_modules
+sites/*/node_modules
+packages/*/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:10.15 as build
+WORKDIR /root
 ENV NODE_ENV production
 ARG SITE
 
-ADD ./ /root
-WORKDIR /root
-RUN yarn --production
+ADD package.json yarn.lock /root/
+ADD packages /root/packages
+ADD sites/$SITE /root/sites/$SITE
+RUN yarn --production --frozen-lockfile
 
 WORKDIR /root/sites/$SITE
 RUN node_modules/.bin/basecms-website build

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@base-cms/image": "^0.9.22",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
     "@base-cms/utils": "^0.9.0",
     "@endeavorb2b/base-website-identity-x": "^0.10.0",
@@ -12,11 +13,6 @@
     "helmet": "^3.16.0",
     "node-fetch": "^2.5.0",
     "vue-recaptcha": "^1.1.1"
-  },
-  "peerDependencies": {
-    "@base-cms/marko-web": "~0.9.29",
-    "graphql": "^14.2.1",
-    "graphql-tag": "^2.10.1"
   },
   "devDependencies": {
     "eslint": "^5.15.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -11,6 +11,8 @@
     "@sendgrid/mail": "^6.4.0",
     "body-parser": "^1.19.0",
     "helmet": "^3.16.0",
+    "graphql": "^14.3.1",
+    "graphql-tag": "^2.10.1",
     "node-fetch": "^2.5.0",
     "vue-recaptcha": "^1.1.1"
   },

--- a/packages/identity-x/package.json
+++ b/packages/identity-x/package.json
@@ -3,6 +3,7 @@
   "version": "0.10.0",
   "private": true,
   "dependencies": {
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
     "@base-cms/utils": "^0.9.0",
     "apollo-cache-inmemory": "^1.6.0",
@@ -14,9 +15,6 @@
     "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "node-fetch": "^2.6.0"
-  },
-  "peerDependencies": {
-    "@base-cms/marko-web": "^0.9.29"
   },
   "devDependencies": {
     "eslint": "^5.15.1",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -3,16 +3,11 @@
   "version": "0.10.0",
   "private": true,
   "dependencies": {
+    "@base-cms/marko-web": "^0.9.29",
+    "@endeavorb2b/base-website-common": "^0.10.0",
     "bootstrap": "4.3.1"
   },
-  "peerDependencies": {
-    "@base-cms/marko-web": "~0.9.29",
-    "@endeavorb2b/base-website-common": "^0.10.0",
-    "graphql": "^14.2.0",
-    "graphql-tag": "^2.10.0"
-  },
   "devDependencies": {
-    "@endeavorb2b/base-website-common": "^0.10.0",
     "stylelint": "^9.10.1",
     "stylelint-config-twbs-bootstrap": "^0.3.0"
   }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -5,7 +5,9 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@endeavorb2b/base-website-common": "^0.10.0",
-    "bootstrap": "4.3.1"
+    "bootstrap": "4.3.1",
+    "graphql": "^14.3.1",
+    "graphql-tag": "^2.10.1"
   },
   "devDependencies": {
     "stylelint": "^9.10.1",

--- a/scripts/deploy-image.sh
+++ b/scripts/deploy-image.sh
@@ -2,14 +2,7 @@
 set -e
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
-mv sites ../
-mkdir sites
-mv ../sites/$1 sites/
-
 docker build -q -t "$1:$2" --build-arg SITE=$1 .
-
-mv ../sites/* sites/
-rm -rf ../sites
 
 docker tag "$1:$2" "endeavorb2b/website-$1:$2"
 docker push "endeavorb2b/website-$1:$2"

--- a/sites/aquamagazine/package.json
+++ b/sites/aquamagazine/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/aquamagazine/package.json
+++ b/sites/aquamagazine/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/aquamagazine/package.json
+++ b/sites/aquamagazine/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/athleticbusiness/package.json
+++ b/sites/athleticbusiness/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/athleticbusiness/package.json
+++ b/sites/athleticbusiness/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/athleticbusiness/package.json
+++ b/sites/athleticbusiness/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/automationworld/package.json
+++ b/sites/automationworld/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/automationworld/package.json
+++ b/sites/automationworld/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/automationworld/package.json
+++ b/sites/automationworld/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/bioopticsworld/package.json
+++ b/sites/bioopticsworld/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/bioopticsworld/package.json
+++ b/sites/bioopticsworld/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/bioopticsworld/package.json
+++ b/sites/bioopticsworld/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/broadbandtechreport/package.json
+++ b/sites/broadbandtechreport/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/broadbandtechreport/package.json
+++ b/sites/broadbandtechreport/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/broadbandtechreport/package.json
+++ b/sites/broadbandtechreport/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/cablinginstall/package.json
+++ b/sites/cablinginstall/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/cablinginstall/package.json
+++ b/sites/cablinginstall/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/cablinginstall/package.json
+++ b/sites/cablinginstall/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/clevescene/package.json
+++ b/sites/clevescene/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/clevescene/package.json
+++ b/sites/clevescene/package.json
@@ -8,7 +8,7 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
     "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",

--- a/sites/clevescene/package.json
+++ b/sites/clevescene/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/dentaleconomics/package.json
+++ b/sites/dentaleconomics/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/dentaleconomics/package.json
+++ b/sites/dentaleconomics/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/dentaleconomics/package.json
+++ b/sites/dentaleconomics/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/dentistryiq/package.json
+++ b/sites/dentistryiq/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/dentistryiq/package.json
+++ b/sites/dentistryiq/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/dentistryiq/package.json
+++ b/sites/dentistryiq/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/evaluationengineering/package.json
+++ b/sites/evaluationengineering/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/evaluationengineering/package.json
+++ b/sites/evaluationengineering/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/evaluationengineering/package.json
+++ b/sites/evaluationengineering/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/forconstructionpros/package.json
+++ b/sites/forconstructionpros/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/forconstructionpros/package.json
+++ b/sites/forconstructionpros/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/forconstructionpros/package.json
+++ b/sites/forconstructionpros/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/healthcarepackaging/package.json
+++ b/sites/healthcarepackaging/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/healthcarepackaging/package.json
+++ b/sites/healthcarepackaging/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/healthcarepackaging/package.json
+++ b/sites/healthcarepackaging/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/industrial-lasers/package.json
+++ b/sites/industrial-lasers/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/industrial-lasers/package.json
+++ b/sites/industrial-lasers/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/industrial-lasers/package.json
+++ b/sites/industrial-lasers/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/intelligent-aerospace/package.json
+++ b/sites/intelligent-aerospace/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/intelligent-aerospace/package.json
+++ b/sites/intelligent-aerospace/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/intelligent-aerospace/package.json
+++ b/sites/intelligent-aerospace/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/laserfocusworld/package.json
+++ b/sites/laserfocusworld/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/laserfocusworld/package.json
+++ b/sites/laserfocusworld/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/laserfocusworld/package.json
+++ b/sites/laserfocusworld/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/ledsmagazine/package.json
+++ b/sites/ledsmagazine/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/ledsmagazine/package.json
+++ b/sites/ledsmagazine/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/ledsmagazine/package.json
+++ b/sites/ledsmagazine/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/lightwaveonline/package.json
+++ b/sites/lightwaveonline/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/lightwaveonline/package.json
+++ b/sites/lightwaveonline/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/lightwaveonline/package.json
+++ b/sites/lightwaveonline/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/metrotimes/package.json
+++ b/sites/metrotimes/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/metrotimes/package.json
+++ b/sites/metrotimes/package.json
@@ -8,7 +8,7 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
     "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",

--- a/sites/metrotimes/package.json
+++ b/sites/metrotimes/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/militaryaerospace/package.json
+++ b/sites/militaryaerospace/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/militaryaerospace/package.json
+++ b/sites/militaryaerospace/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/militaryaerospace/package.json
+++ b/sites/militaryaerospace/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/oemmagazine/package.json
+++ b/sites/oemmagazine/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/oemmagazine/package.json
+++ b/sites/oemmagazine/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/oemmagazine/package.json
+++ b/sites/oemmagazine/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/officer/package.json
+++ b/sites/officer/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/officer/package.json
+++ b/sites/officer/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/officer/package.json
+++ b/sites/officer/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/offshore-mag/package.json
+++ b/sites/offshore-mag/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/offshore-mag/package.json
+++ b/sites/offshore-mag/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/offshore-mag/package.json
+++ b/sites/offshore-mag/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/ogj/package.json
+++ b/sites/ogj/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-identity-x": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",

--- a/sites/ogj/package.json
+++ b/sites/ogj/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-identity-x": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",

--- a/sites/ogj/package.json
+++ b/sites/ogj/package.json
@@ -15,7 +15,7 @@
     "@endeavorb2b/base-website-identity-x": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/orlandoweekly/package.json
+++ b/sites/orlandoweekly/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/orlandoweekly/package.json
+++ b/sites/orlandoweekly/package.json
@@ -8,7 +8,7 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
     "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",

--- a/sites/orlandoweekly/package.json
+++ b/sites/orlandoweekly/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/outinsa/package.json
+++ b/sites/outinsa/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/outinsa/package.json
+++ b/sites/outinsa/package.json
@@ -8,7 +8,7 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
     "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",

--- a/sites/outinsa/package.json
+++ b/sites/outinsa/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/outinstl/package.json
+++ b/sites/outinstl/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/outinstl/package.json
+++ b/sites/outinstl/package.json
@@ -8,7 +8,7 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
     "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",

--- a/sites/outinstl/package.json
+++ b/sites/outinstl/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/packworld/package.json
+++ b/sites/packworld/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/packworld/package.json
+++ b/sites/packworld/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/packworld/package.json
+++ b/sites/packworld/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/perioimplantadvisory/package.json
+++ b/sites/perioimplantadvisory/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/perioimplantadvisory/package.json
+++ b/sites/perioimplantadvisory/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/perioimplantadvisory/package.json
+++ b/sites/perioimplantadvisory/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/plasticsmachinerymagazine/package.json
+++ b/sites/plasticsmachinerymagazine/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/plasticsmachinerymagazine/package.json
+++ b/sites/plasticsmachinerymagazine/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/plasticsmachinerymagazine/package.json
+++ b/sites/plasticsmachinerymagazine/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/profoodworld/package.json
+++ b/sites/profoodworld/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/profoodworld/package.json
+++ b/sites/profoodworld/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/profoodworld/package.json
+++ b/sites/profoodworld/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/rdhmag/package.json
+++ b/sites/rdhmag/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/rdhmag/package.json
+++ b/sites/rdhmag/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/rdhmag/package.json
+++ b/sites/rdhmag/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/riverfronttimes/package.json
+++ b/sites/riverfronttimes/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/riverfronttimes/package.json
+++ b/sites/riverfronttimes/package.json
@@ -8,7 +8,7 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
     "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",

--- a/sites/riverfronttimes/package.json
+++ b/sites/riverfronttimes/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/sacurrent/package.json
+++ b/sites/sacurrent/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/sacurrent/package.json
+++ b/sites/sacurrent/package.json
@@ -8,7 +8,7 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
     "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",

--- a/sites/sacurrent/package.json
+++ b/sites/sacurrent/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/strategies-u/package.json
+++ b/sites/strategies-u/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/strategies-u/package.json
+++ b/sites/strategies-u/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/strategies-u/package.json
+++ b/sites/strategies-u/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/utilityproducts/package.json
+++ b/sites/utilityproducts/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/utilityproducts/package.json
+++ b/sites/utilityproducts/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/utilityproducts/package.json
+++ b/sites/utilityproducts/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/vision-systems/package.json
+++ b/sites/vision-systems/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/vision-systems/package.json
+++ b/sites/vision-systems/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/vision-systems/package.json
+++ b/sites/vision-systems/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/waterworld/package.json
+++ b/sites/waterworld/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/waterworld/package.json
+++ b/sites/waterworld/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/waterworld/package.json
+++ b/sites/waterworld/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/woodfloorbusiness/package.json
+++ b/sites/woodfloorbusiness/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "^0.9.31",
+    "@base-cms/web-cli": "^0.9.33",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/sites/woodfloorbusiness/package.json
+++ b/sites/woodfloorbusiness/package.json
@@ -14,7 +14,7 @@
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1",
     "newrelic": "^5.7.0"
   }

--- a/sites/woodfloorbusiness/package.json
+++ b/sites/woodfloorbusiness/package.json
@@ -8,9 +8,9 @@
     "lint": "basecms-website lint"
   },
   "dependencies": {
-    "@base-cms/marko-web": "~0.9.29",
+    "@base-cms/marko-web": "^0.9.29",
     "@base-cms/object-path": "^0.9.0",
-    "@base-cms/web-cli": "~0.9.31",
+    "@base-cms/web-cli": "^0.9.31",
     "@endeavorb2b/base-website-common": "^0.10.0",
     "@endeavorb2b/base-website-themes": "^0.10.0",
     "@newrelic/native-metrics": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -651,7 +651,7 @@
   dependencies:
     inflected "^2.0.4"
 
-"@base-cms/marko-web@^0.9.29", "@base-cms/marko-web@~0.9.29":
+"@base-cms/marko-web@^0.9.29":
   version "0.9.29"
   resolved "https://registry.yarnpkg.com/@base-cms/marko-web/-/marko-web-0.9.29.tgz#760c994a3baa7b752089f9b7a4da7e3e27a201a6"
   integrity sha512-2UciMlFKl4gt90HmUPydsCiUJt/63rf49wnUgzZq6nV8NCbHVGXQRYxi2RM4nMw1lyZz8RATM8efWopiKZrPrQ==
@@ -690,7 +690,7 @@
   resolved "https://registry.yarnpkg.com/@base-cms/utils/-/utils-0.9.0.tgz#a54bfbd119aaf310ff4cbd0e3ae253f4ecfa8b27"
   integrity sha512-g7+XxYSqtBclVj0FgbRiai70DR+px8oun1jPiOw3hOIUOvlDx1fc7VRsKKWmD+V40t6xYFyJX5qSfTYxqvJvOQ==
 
-"@base-cms/web-cli@^0.9.31", "@base-cms/web-cli@~0.9.31":
+"@base-cms/web-cli@^0.9.31":
   version "0.9.31"
   resolved "https://registry.yarnpkg.com/@base-cms/web-cli/-/web-cli-0.9.31.tgz#d77b7bd5baa18e1700d936acbfa4841fa0d662f9"
   integrity sha512-O6CyBH+iARYg2I8coIsKgclDn/P/M8qe5wOToZprU86BRVYGNr1nN2vqCSI8xzGKdaIig6Gc+/S3dZ88eD0peA==


### PR DESCRIPTION
In addition:
- use same `@base-cms` version specificity across all packages/sites (i.e. no longer combine `~` with `^`)
- use same `graphql` version across all packages/sites
- add required `@base-cms` peer deps as common package dependencies
- upgrade `@base-cms/web-cli` to `0.9.33` to ensure bad builds exit with 1