### PR TITLE
Send website package version as header

### DIFF
--- a/packages/common/on-start.js
+++ b/packages/common/on-start.js
@@ -1,8 +1,12 @@
 const helmet = require('helmet');
 
 // Set global express settings/middlewares for _all_ websites that use this function.
-module.exports = (app) => {
+module.exports = version => (app) => {
   app.set('trust proxy', 'loopback, linklocal, uniquelocal');
+  app.use((req, res, next) => {
+    res.set('x-version', version);
+    next();
+  });
   app.use(helmet({
     frameguard: false,
   }));

--- a/sites/aquamagazine/index.js
+++ b/sites/aquamagazine/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/athleticbusiness/index.js
+++ b/sites/athleticbusiness/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/automationworld/index.js
+++ b/sites/automationworld/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/bioopticsworld/index.js
+++ b/sites/bioopticsworld/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/broadbandtechreport/index.js
+++ b/sites/broadbandtechreport/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/cablinginstall/index.js
+++ b/sites/cablinginstall/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/clevescene/index.js
+++ b/sites/clevescene/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/dentaleconomics/index.js
+++ b/sites/dentaleconomics/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/dentistryiq/index.js
+++ b/sites/dentistryiq/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/evaluationengineering/index.js
+++ b/sites/evaluationengineering/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/forconstructionpros/index.js
+++ b/sites/forconstructionpros/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/healthcarepackaging/index.js
+++ b/sites/healthcarepackaging/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/industrial-lasers/index.js
+++ b/sites/industrial-lasers/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/intelligent-aerospace/index.js
+++ b/sites/intelligent-aerospace/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/laserfocusworld/index.js
+++ b/sites/laserfocusworld/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/ledsmagazine/index.js
+++ b/sites/ledsmagazine/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/lightwaveonline/index.js
+++ b/sites/lightwaveonline/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/metrotimes/index.js
+++ b/sites/metrotimes/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/militaryaerospace/index.js
+++ b/sites/militaryaerospace/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/oemmagazine/index.js
+++ b/sites/oemmagazine/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/officer/index.js
+++ b/sites/officer/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/offshore-mag/index.js
+++ b/sites/offshore-mag/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/ogj/index.js
+++ b/sites/ogj/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/orlandoweekly/index.js
+++ b/sites/orlandoweekly/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/outinsa/index.js
+++ b/sites/outinsa/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/outinstl/index.js
+++ b/sites/outinstl/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/packworld/index.js
+++ b/sites/packworld/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/perioimplantadvisory/index.js
+++ b/sites/perioimplantadvisory/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/plasticsmachinerymagazine/index.js
+++ b/sites/plasticsmachinerymagazine/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/profoodworld/index.js
+++ b/sites/profoodworld/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/rdhmag/index.js
+++ b/sites/rdhmag/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/riverfronttimes/index.js
+++ b/sites/riverfronttimes/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/sacurrent/index.js
+++ b/sites/sacurrent/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/strategies-u/index.js
+++ b/sites/strategies-u/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/utilityproducts/index.js
+++ b/sites/utilityproducts/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/vision-systems/index.js
+++ b/sites/vision-systems/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/waterworld/index.js
+++ b/sites/waterworld/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/woodfloorbusiness/index.js
+++ b/sites/woodfloorbusiness/index.js
@@ -2,6 +2,7 @@ require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
 const onStart = require('@endeavorb2b/base-website-common/on-start');
 const errorTemplate = require('@endeavorb2b/base-website-themes/pennwell/templates/error');
+const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
 const coreConfig = require('./config/core');
@@ -14,5 +15,5 @@ startServer({
   siteConfig,
   routes,
   errorTemplate,
-  onStart,
+  onStart: onStart(version),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));


### PR DESCRIPTION
Displays the website `package.json` version via the `x-version` header on all responses.