### PR TITLE
Ensure cookie header is string before parsing

### DIFF
--- a/packages/identity-x/utils/token-cookie.js
+++ b/packages/identity-x/utils/token-cookie.js
@@ -8,9 +8,14 @@ const setTo = (res, token) => {
 };
 
 const getFrom = (req) => {
-  const cookies = cookie.parse(req.get('cookie'));
-  const { [COOKIE_NAME]: token } = cookies;
-  return token;
+  try {
+    const cookies = cookie.parse(req.get('cookie') || '');
+    const { [COOKIE_NAME]: token } = cookies;
+    return token;
+  } catch (e) {
+    // @todo log this error.
+    return undefined;
+  }
 };
 
 const removeFrom = (res) => {


### PR DESCRIPTION
And also prevent any other errors from fatally killing the page.