### PR TITLE
CS-2272: Corrected path on ILS to go to /commentary

### DIFF
--- a/sites/industrial-lasers/config/site.js
+++ b/sites/industrial-lasers/config/site.js
@@ -50,7 +50,7 @@ module.exports = {
   ],
   menuItems: {
     resources: [
-      { href: '/blogs', label: 'Commentary' },
+      { href: '/commentary', label: 'Commentary' },
       { href: '/magazine', label: 'Magazine' },
       { href: '/videos', label: 'Videos' },
       { href: '/white-papers', label: 'White Papers' },


### PR DESCRIPTION
Not sure why it was labeled commentary, when the other sites were labeled blogs, but I missed checking the link.

https://southcomm.atlassian.net/projects/CS/queues/custom/12/CS-2272