### PR TITLE
CS2291: UP secure link was requesting insecure

### DIFF
--- a/sites/utilityproducts/config/site.js
+++ b/sites/utilityproducts/config/site.js
@@ -67,7 +67,7 @@ module.exports = {
     apiKey: '003355913687346718228:mb2grfhfx08',
   },
   subscriptions: {
-    newsletters: 'https://endeavor.dragonforms.com/UPPrefPage',
+    newsletters: 'https://endeavor.dragonforms.com/loading.do?omedasite=UPPrefPage',
     publications: {
       '/subscribe/print/up': 'https://formdesigner.ecn5.com/GetForm?tokenuid=e97538ee-c358-44e2-9cb2-ccd37cdd79ae&promoCode=N9WEB&utm_source=mag_sub&utm_medium=website&utm_campaign=N9WEB&utm_content=2019-02-26',
     },


### PR DESCRIPTION
https://endeavor.dragonforms.com/UPPrefPage was requesting http://endeavor.dragonforms.com/loading.do?omedasite=UPPrefPage (insecure script). Didn’t notice an issue on local, but the script won’t load on live.

Updated to request a secure loading script: https://endeavor.dragonforms.com/loading.do?omedasite=UPPrefPage