### PR TITLE
WW-Municipal: drinking water appeared twice

### DIFF
--- a/sites/waterworld/server/templates/website-section/municipal.marko
+++ b/sites/waterworld/server/templates/website-section/municipal.marko
@@ -54,8 +54,8 @@ $ const adSlots = {
   <div class="row">
     <div class="col-lg-4 mb-block">
       <endeavor-content-query-section-list
-        section-alias="municipal/drinking-water"
-        header={ title: "Drinking Water", href: "/municipal/drinking-water" }
+        section-alias="municipal/water-utility-management"
+        header={ title: "Water Utility Management", href: "/municipal/water-utility-management" }
       />
     </div>
     <div class="col-lg-4 mb-block">


### PR DESCRIPTION
Per Brandon, replaced the second drinking water with /municipal/water-utility-management

https://3.basecamp.com/4053736/buckets/11134315/todos/1778036889 and https://3.basecamp.com/4053736/buckets/11134315/todos/1778018885