### PR TITLE
Adjust item__asset-image styling

### DIFF
--- a/packages/themes/pennwell/styles/components/_item.scss
+++ b/packages/themes/pennwell/styles/components/_item.scss
@@ -127,6 +127,8 @@
   }
 
   &__asset-image {
+    max-width: 100%;
+    height: auto;
     border-radius: $border-radius;
   }
 


### PR DESCRIPTION
Added a max-width: 100% and height: auto on item images to prevent them overflowing container

See: https://3.basecamp.com/4053736/buckets/11134315/todos/1766653565