### PR TITLE
Cs2137 dates on event based content

### DIFF
--- a/packages/common/components/content/blocks/page-header.marko
+++ b/packages/common/components/content/blocks/page-header.marko
@@ -15,7 +15,11 @@ $ const specialTypes = ['event', 'webinar', 'whitepaper'];
   </if>
   <if(content.type === 'event')>
     <p class="page-wrapper__event-date">
-      <endeavor-content-starts obj=input.content/> - <endeavor-content-ends obj=input.content/>
+      <endeavor-content-starts obj=input.content />
+      <if(content.ends)>
+        <span class="page-wrapper__event-date-divider"> - </span>
+        <endeavor-content-ends obj=input.content/>
+      </if>
     </p>
   </if>
     <if(content.type === 'webinar')>

--- a/packages/common/components/content/blocks/page-header.marko
+++ b/packages/common/components/content/blocks/page-header.marko
@@ -1,6 +1,7 @@
 import { getAsObject } from '@base-cms/object-path';
 
 $ const content = getAsObject(input, 'content');
+$ const specialTypes = ['event', 'webinar', 'whitepaper'];
 
 <div class="page-wrapper__header">
   <endeavor-breadcrumbs-website-section section=content.primarySection />
@@ -8,6 +9,18 @@ $ const content = getAsObject(input, 'content');
   <cms-content-teaser tag="p" class="page-wrapper__deck" obj=input.content />
   <if(content.type !== 'contact')>
     <endeavor-content-block-attribution content=input.content />
-    <cms-content-published obj=input.content />
+  </if>
+  <if(content.type !== 'contact' && !specialTypes.includes(content.type))>
+    <cms-content-published class="page-wrapper__date" obj=input.content />
+  </if>
+  <if(content.type === 'event')>
+    <p class="page-wrapper__event-date">
+      <endeavor-content-starts obj=input.content/> - <endeavor-content-ends obj=input.content/>
+    </p>
+  </if>
+    <if(content.type === 'webinar')>
+    <p class="page-wrapper__starts-date">
+      <endeavor-content-starts obj=input.content/>
+    </p>
   </if>
 </div>

--- a/packages/themes/pennwell/api/fragments/content-page.js
+++ b/packages/themes/pennwell/api/fragments/content-page.js
@@ -43,8 +43,13 @@ fragment ContentPageFragment on Content {
     source
     byline
   }
+  ... on ContentEvent {
+    ends
+    starts
+  }
   ... on ContentWebinar {
     linkUrl
+    starts
     sponsors {
       edges {
         node {


### PR DESCRIPTION
Debra approved the setup. No date on whitepapers, start date on webcasts, and a start-end date on events (unless it is a single day event, in which case, it would only show a start date).