### PR TITLE
Date adjustments for event based content

### DIFF
--- a/packages/common/components/content/blocks/page-header.marko
+++ b/packages/common/components/content/blocks/page-header.marko
@@ -1,7 +1,7 @@
 import { getAsObject } from '@base-cms/object-path';
 
 $ const content = getAsObject(input, 'content');
-$ const noPublishDateContentTypes = ['event', 'webinar', 'whitepaper', 'contact'];
+$ const noPublishDateContentTypes = ['event', 'webinar', 'contact'];
 
 <endeavor-breadcrumbs-website-section section=content.primarySection />
 <cms-content-name tag="h1" class="page-wrapper__title" obj=input.content />

--- a/packages/common/components/content/blocks/page-header.marko
+++ b/packages/common/components/content/blocks/page-header.marko
@@ -7,22 +7,15 @@ $ const noPublishDateContentTypes = ['event', 'webinar', 'contact'];
 <cms-content-name tag="h1" class="page-wrapper__title" obj=input.content />
 <cms-content-teaser tag="p" class="page-wrapper__deck" obj=input.content />
 <if(content.type === 'event')>
-  <p class="page-wrapper__event-date">
     <endeavor-content-starts obj=input.content />
-    <if(content.ends)>
-      <span class="page-wrapper__event-date-divider"> - </span>
-      <endeavor-content-ends obj=input.content/>
-    </if>
-  </p>
+    <endeavor-content-ends class="page-wrapper__ends-date" obj=input.content/>
 </if>
 <if(content.type === 'webinar')>
-  <p class="page-wrapper__starts-date">
     <endeavor-content-starts obj=input.content/>
-  </p>
 </if>
 <if(content.type !== 'contact')>
   <endeavor-content-block-attribution content=input.content />
 </if>
 <if(!noPublishDateContentTypes.includes(content.type))>
-  <cms-content-published class="page-wrapper__date" obj=input.content />
+  <cms-content-published obj=input.content />
 </if>

--- a/packages/common/components/content/blocks/page-header.marko
+++ b/packages/common/components/content/blocks/page-header.marko
@@ -7,11 +7,11 @@ $ const noPublishDateContentTypes = ['event', 'webinar', 'contact'];
 <cms-content-name tag="h1" class="page-wrapper__title" obj=input.content />
 <cms-content-teaser tag="p" class="page-wrapper__deck" obj=input.content />
 <if(content.type === 'event')>
-    <endeavor-content-starts obj=input.content />
-    <endeavor-content-ends class="page-wrapper__ends-date" obj=input.content/>
+    <endeavor-content-starts block="item" obj=input.content />
+    <endeavor-content-ends block="item" obj=input.content/>
 </if>
 <if(content.type === 'webinar')>
-    <endeavor-content-starts obj=input.content/>
+    <endeavor-content-starts block="item" obj=input.content/>
 </if>
 <if(content.type !== 'contact')>
   <endeavor-content-block-attribution content=input.content />

--- a/packages/common/components/content/blocks/page-header.marko
+++ b/packages/common/components/content/blocks/page-header.marko
@@ -1,11 +1,24 @@
 import { getAsObject } from '@base-cms/object-path';
 
 $ const content = getAsObject(input, 'content');
+$ const specialTypes = ['event', 'webinar', 'whitepaper'];
 
 <endeavor-breadcrumbs-website-section section=content.primarySection />
 <cms-content-name tag="h1" class="page-wrapper__title" obj=input.content />
 <cms-content-teaser tag="p" class="page-wrapper__deck" obj=input.content />
 <if(content.type !== 'contact')>
   <endeavor-content-block-attribution content=input.content />
-  <cms-content-published obj=input.content />
+</if>
+<if(content.type !== 'contact' && !specialTypes.includes(content.type))>
+  <cms-content-published class="page-wrapper__date" obj=input.content />
+</if>
+<if(content.type === 'event')>
+  <p class="page-wrapper__event-date">
+    <endeavor-content-starts obj=input.content/> - <endeavor-content-ends obj=input.content/>
+  </p>
+</if>
+  <if(content.type === 'webinar')>
+  <p class="page-wrapper__starts-date">
+    <endeavor-content-starts obj=input.content/>
+  </p>
 </if>

--- a/packages/common/components/content/blocks/page-header.marko
+++ b/packages/common/components/content/blocks/page-header.marko
@@ -1,17 +1,11 @@
 import { getAsObject } from '@base-cms/object-path';
 
 $ const content = getAsObject(input, 'content');
-$ const specialTypes = ['event', 'webinar', 'whitepaper'];
+$ const noPublishDateContentTypes = ['event', 'webinar', 'whitepaper', 'contact'];
 
 <endeavor-breadcrumbs-website-section section=content.primarySection />
 <cms-content-name tag="h1" class="page-wrapper__title" obj=input.content />
 <cms-content-teaser tag="p" class="page-wrapper__deck" obj=input.content />
-<if(content.type !== 'contact')>
-  <endeavor-content-block-attribution content=input.content />
-</if>
-<if(content.type !== 'contact' && !specialTypes.includes(content.type))>
-  <cms-content-published class="page-wrapper__date" obj=input.content />
-</if>
 <if(content.type === 'event')>
   <p class="page-wrapper__event-date">
     <endeavor-content-starts obj=input.content />
@@ -25,4 +19,10 @@ $ const specialTypes = ['event', 'webinar', 'whitepaper'];
   <p class="page-wrapper__starts-date">
     <endeavor-content-starts obj=input.content/>
   </p>
+</if>
+<if(content.type !== 'contact')>
+  <endeavor-content-block-attribution content=input.content />
+</if>
+<if(!noPublishDateContentTypes.includes(content.type))>
+  <cms-content-published class="page-wrapper__date" obj=input.content />
 </if>

--- a/packages/common/components/content/blocks/page-header.marko
+++ b/packages/common/components/content/blocks/page-header.marko
@@ -14,10 +14,14 @@ $ const specialTypes = ['event', 'webinar', 'whitepaper'];
 </if>
 <if(content.type === 'event')>
   <p class="page-wrapper__event-date">
-    <endeavor-content-starts obj=input.content/> - <endeavor-content-ends obj=input.content/>
+    <endeavor-content-starts obj=input.content />
+    <if(content.ends)>
+      <span class="page-wrapper__event-date-divider"> - </span>
+      <endeavor-content-ends obj=input.content/>
+    </if>
   </p>
 </if>
-  <if(content.type === 'webinar')>
+<if(content.type === 'webinar')>
   <p class="page-wrapper__starts-date">
     <endeavor-content-starts obj=input.content/>
   </p>

--- a/packages/themes/pennwell/api/fragments/content-page.js
+++ b/packages/themes/pennwell/api/fragments/content-page.js
@@ -47,8 +47,13 @@ fragment ContentPageFragment on Content {
     source
     byline
   }
+  ... on ContentEvent {
+    ends
+    starts
+  }
   ... on ContentWebinar {
     linkUrl
+    starts
     sponsors {
       edges {
         node {

--- a/packages/themes/pennwell/styles/components/_page.scss
+++ b/packages/themes/pennwell/styles/components/_page.scss
@@ -40,11 +40,4 @@
     @include theme-page-body-spacing();
   }
 
-  &__ends-date {
-    &::before {
-      margin-right: map-get($spacers, 1);
-      margin-left: map-get($spacers, 1);
-      content: "\2014";
-    }
-  }
 }

--- a/packages/themes/pennwell/styles/components/_page.scss
+++ b/packages/themes/pennwell/styles/components/_page.scss
@@ -39,4 +39,12 @@
   &__body {
     @include theme-page-body-spacing();
   }
+
+  &__ends-date {
+    &::before {
+      margin-right: map-get($spacers, 1);
+      margin-left: map-get($spacers, 1);
+      content: "\2014";
+    }
+  }
 }


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/CS-2187

Updated events and webinars dates to correspond with the the date range for the event and the start date for the webinar. Added if for one day events, plus a class to target the date for any css changes down the line.

Debra approved the setup. No date on whitepapers, start date on webcasts, and a start-end date on events (unless it is a single day event, in which case, it would only show a start date).