### PR TITLE
OGJ layout, menu updates

### DIFF
--- a/packages/common/components/content/blocks/query-feed.marko
+++ b/packages/common/components/content/blocks/query-feed.marko
@@ -19,6 +19,9 @@ $ const nativeXEnabled = useNativeX(site, {
   aliases: nativeX.aliases,
 });
 $ const imageOptions = { w: 120, h: 120, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 };
+$ const withImage = input.withImage === undefined ? true : Boolean(input.withImage);
+$ const withSection = input.withSection === undefined ? true : Boolean(input.withSection);
+$ const usePlaceholder = input.usePlaceholder === undefined ? true : Boolean(input.usePlaceholder);
 
 <cms-query-website-scheduled-content|{ nodes, pageInfo }| ...params>
   $ const listNodes = asArray(nodes);
@@ -42,10 +45,13 @@ $ const imageOptions = { w: 120, h: 120, fit: 'crop', crop: 'focalpoint', fpX: 0
           <else>
             <endeavor-content-block-item
               content=item
-              image-position="left"
+              image-position="right"
               image-options=imageOptions
               image-width=75
               image-height=75
+              with-image=withImage
+              with-section=withSection
+              image-use-placeholder=usePlaceholder
             />
           </else>
         </@item>

--- a/sites/ogj/config/site.js
+++ b/sites/ogj/config/site.js
@@ -36,7 +36,9 @@ module.exports = {
   secondaryNavItems: [
     { href: '/subscribe', label: 'Subscribe' },
     { href: '/magazine', label: 'Magazine' },
-    { href: '/videos', label: 'Videos' },
+    { href: '/past-issues', label: 'Past Issues' },
+    { href: '/ogj-survey-downloads', label: 'Surveys' },
+    { href: '/industry-statistics', label: 'Industry Statistics' },
     { href: '/page/about-us', label: 'About Us' },
   ],
   tertiaryNavItems: [
@@ -52,9 +54,14 @@ module.exports = {
   menuItems: {
     resources: [
       { href: '/magazine', label: 'Magazine' },
+      { href: '/past-issues', label: 'Past Issues' },
       { href: '/videos', label: 'Videos' },
       { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },
+      { href: 'https://www.pennwellbooks.com/categories/petroleum.html', label: 'Bookstore' },
+      { href: 'https://ogjresearch.com/', label: 'Research' },
+      { href: '/ogj-survey-downloads', label: 'Surveys' },
+      { href: '/industry-statistics', label: 'Industry Statistics' },
     ],
     userTools: [
       ...userLinks,

--- a/sites/ogj/server/templates/index.marko
+++ b/sites/ogj/server/templates/index.marko
@@ -31,16 +31,16 @@ $ const adSlots = {
           <div class="item item--card item--image-left">
             <!-- @todo This is hardcoded for demo purposes only. Change this!!! -->
             <div class="item__image">
-              <a href="/">
+              <!-- <a href="/">
                 <img src="https://avatars1.githubusercontent.com/u/42003920?s=200&v=4" class="item__asset-image" width="75" height="75" />
-              </a>
+              </a> -->
             </div>
             <div class="item__contents">
               <h5 class="item__title item__title--large">
                 ${team.name}
               </h5>
               <p class="item__description">
-                Welcome to ${out.global.config.siteName()}. Informational text would reside here.
+                Welcome to ${out.global.config.siteName()}.
               </p>
             </div>
           </div>
@@ -49,86 +49,112 @@ $ const adSlots = {
     </if>
   </identity-x>
 
-  <endeavor-content-query-hero
-    section-id=section.id
-    limit=5
-  />
-
-
   <div class="row">
     <div class="col-lg-8">
       <div class="row">
         <div class="col-lg-6 mb-block">
           <endeavor-content-query-section-list
-            limit=3
-            section-alias="general-interest"
-            header={ title: "General Interest", href: "/general-interest" }
-            native-x={ placement: 'list1', aliases: ['general-interest'], index: 2 }
+            limit=5
+            section-id=section.id
+            requires-image=false
+            use-placeholder=false
+            header={ title: "Latest Content from OGJ" }
           />
         </div>
         <div class="col-lg-6 mb-block">
-          <endeavor-content-query-section-list
-            limit=3
-            section-alias="exploration-development"
-            header={ title: "Exploration & Development", href: "/exploration-development" }
-            native-x={ placement: 'list1', aliases: ['exploration-development'], index: 2 }
-          />
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-lg-6 mb-block">
-          <endeavor-content-query-section-list
-            limit=3
-            section-alias="drilling-production"
-            header={ title: "Drilling & Production", href: "/drilling-production" }
-            native-x={ placement: 'list1', aliases: ['drilling-production'], index: 2 }
-          />
-        </div>
-        <div class="col-lg-6 mb-block">
-          <endeavor-content-query-section-list
-            limit=3
-            section-alias="refining-processing"
-            header={ title: "Refining & Processing", href: "/refining-processing" }
-            native-x={ placement: 'list1', aliases: ['refining-processing'], index: 2 }
+          <endeavor-magazine-query-latest-issue
+            publication-id="5ca3d91475a2545c040041a9"
+            header="Current Issue"
+            as-card=true
+            content-count=0
           />
         </div>
       </div>
     </div>
-    <div class="col-lg-4 ad-rail">
-      <endeavor-gam-ad-unit-display id="gpt-ad-rail1" />
-      <endeavor-gam-ad-unit-display id="gpt-ad-rail2" />
+
+    <identity-x|{ mergedTeams }|>
+      <if(mergedTeams.length)>
+        <div class="col-lg-4 mb-block">
+          <endeavor-content-query-section-list
+            limit=5
+            section-alias="ogj-survey-downloads"
+            requires-image=false
+            use-placeholder=false
+            header={ title: "Survey Downloads", href: "/ogj-survey-downloads" }
+          />
+        </div>
+      </if>
+      <else>
+        <div class="col-lg-4 ad-rail">
+          <endeavor-gam-ad-unit-display id="gpt-ad-rail1" />
+          <endeavor-gam-ad-unit-display id="gpt-ad-rail2" />
+        </div>
+      </else>
+    </identity-x>
+
+  </div>
+
+  <div class="row">
+    <div class="col-lg-4 mb-block">
+      <endeavor-content-query-section-list
+        limit=4
+        section-alias="general-interest"
+        header={ title: "General Interest", href: "/general-interest" }
+        requires-image=false
+        use-placeholder=false
+        native-x={ placement: 'list1', aliases: ['general-interest'], index: 3 }
+      />
+    </div>
+    <div class="col-lg-4 mb-block">
+      <endeavor-content-query-section-list
+        limit=4
+        section-alias="exploration-development"
+        header={ title: "Exploration & Development", href: "/exploration-development" }
+        requires-image=false
+        use-placeholder=false
+        native-x={ placement: 'list1', aliases: ['exploration-development'], index: 3 }
+      />
+    </div>
+    <div class="col-lg-4 mb-block">
+      <endeavor-content-query-section-list
+        limit=4
+        section-alias="drilling-production"
+        header={ title: "Drilling & Production", href: "/drilling-production" }
+        requires-image=false
+        use-placeholder=false
+        native-x={ placement: 'list1', aliases: ['drilling-production'], index: 3 }
+      />
     </div>
   </div>
 
   <div class="row">
     <div class="col-lg-4 mb-block">
       <endeavor-content-query-section-list
-        limit=3
+        limit=4
+        section-alias="refining-processing"
+        header={ title: "Refining & Processing", href: "/refining-processing" }
+        requires-image=false
+        use-placeholder=false
+        native-x={ placement: 'list1', aliases: ['refining-processing'], index: 3 }
+      />
+    </div>
+    <div class="col-lg-4 mb-block">
+      <endeavor-content-query-section-list
+        limit=4
         section-alias="pipelines-transportation"
         header={ title: "Pipelines & Transportation", href: "/pipelines-transportation" }
-        native-x={ placement: 'list1', aliases: ['pipelines-transportation'], index: 2 }
+        requires-image=false
+        use-placeholder=false
+        native-x={ placement: 'list1', aliases: ['pipelines-transportation'], index: 3 }
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <theme-pennwell-published-content-query-list
-        query={
-          requiresImage: false,
-          contentTypes: ["Whitepaper"],
-          limit: 3,
-        }
-        with-image=false
-        header={ title: "White Papers", href: "/white-papers" }
-      />
-    </div>
-    <div class="col-lg-4 mb-block">
-      <theme-pennwell-published-content-query-list
-        query={
-          requiresImage: false,
-          contentTypes: ["Webinar"],
-          limit: 3,
-        }
-        with-image=false
-        header={ title: "Webcasts", href: "/webcasts" }
+      <endeavor-content-query-section-list
+        limit=4
+        section-alias="editors-perspective"
+        requires-image=false
+        use-placeholder=false
+        header={ title: "Editor's Perspective", href: "/editors-perspective" }
       />
     </div>
   </div>
@@ -144,19 +170,25 @@ $ const adSlots = {
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-content-query-section-list
-        limit=4
-        skip=5
-        section-alias=section.alias
-        header={ title: `More from ${out.global.config.siteName()}` }
+      <theme-pennwell-published-content-query-list
+        query={
+          requiresImage: false,
+          contentTypes: ["Whitepaper"],
+          limit: 4,
+        }
+        with-image=false
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue
-        publication-id="5ca3d91475a2545c040041a9"
-        header="Current Issue"
-        as-card=true
-        content-count=0
+      <theme-pennwell-published-content-query-list
+        query={
+          requiresImage: false,
+          contentTypes: ["Webinar"],
+          limit: 4,
+        }
+        with-image=false
+        header={ title: "Webcasts", href: "/webcasts" }
       />
     </div>
   </div>

--- a/sites/ogj/server/templates/website-section/index.marko
+++ b/sites/ogj/server/templates/website-section/index.marko
@@ -22,7 +22,7 @@ $ const adSlots = {
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <div class="page-wrapper default-page">
+  <div class="page-wrapper">
     <div class="row">
       <div class="col">
         <div class="page-wrapper__header">

--- a/sites/ogj/server/templates/website-section/index.marko
+++ b/sites/ogj/server/templates/website-section/index.marko
@@ -22,7 +22,7 @@ $ const adSlots = {
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <div class="page-wrapper">
+  <div class="page-wrapper mb-block">
     <div class="row">
       <div class="col">
         <div class="page-wrapper__header">
@@ -44,6 +44,8 @@ $ const adSlots = {
         limit=7
         skip=5
         section-id=section.id
+        requires-image=false
+        use-placeholder=false
       />
     </div>
     <div class="col-lg-4 ad-rail">

--- a/sites/ogj/server/templates/website-section/index.marko
+++ b/sites/ogj/server/templates/website-section/index.marko
@@ -22,16 +22,25 @@ $ const adSlots = {
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <endeavor-content-query-hero
-    section-id=section.id
-    limit=5
-  />
+  <div class="page-wrapper default-page">
+    <div class="row">
+      <div class="col">
+        <div class="page-wrapper__header">
+          <endeavor-breadcrumbs-website-section section=section />
+          <h1 class="page-wrapper__title">${section.name}</h1>
+          <if(section.description)>
+            <p class="page-wrapper__description">${section.description}</p>
+          </if>
+        </div>
+      </div>
+    </div>
+  </div>
 
 
   <div class="row">
     <div class="col-lg-8">
       <endeavor-content-query-feed
-        header="Featured"
+        header="Latest"
         limit=7
         skip=5
         section-id=section.id


### PR DESCRIPTION
Primary change here is to the home page layout; ads in the right rail are dropped in favor of Survey Downloads when a site license customer views it.  Dropped the static logo until it can be dynamically pulled in.

**Anonymous User:**
![ogj-anonymous](https://user-images.githubusercontent.com/2855198/59715542-b8733700-91d9-11e9-881c-1e6ff61c0960.png)

**Site License User:**
![ogj-site-license](https://user-images.githubusercontent.com/2855198/59715577-cd4fca80-91d9-11e9-8a94-8bdfdb3a9e14.png)
