### PR TITLE
Reduce archive icons on mobile to match desktop

### DIFF
--- a/packages/themes/pennwell/styles/components/magazine/_query-archives.scss
+++ b/packages/themes/pennwell/styles/components/magazine/_query-archives.scss
@@ -6,12 +6,7 @@
   &__col {
     margin-bottom: map-get($spacers, block);
     @include make-col-ready();
-    @include media-breakpoint-up(sm) {
-      @include make-col(6);
-    }
-    @include media-breakpoint-up(md) {
-      @include make-col(4);
-    }
+    @include make-col(4);
     &:last-child {
       @include media-breakpoint-down(sm) {
         display: none;


### PR DESCRIPTION
https://3.basecamp.com/4053736/buckets/11134315/todos/1824238920

Prevent users from having to scroll through multiple archived volumes to get to the magazine content

Current:

https://files.slack.com/files-pri/TDA6JTAKC-FKJ4G0LAD/screen_shot_2019-06-19_at_4.24.22_pm.png

New:

https://files.slack.com/files-pri/TDA6JTAKC-FKQ0ZCU04/screen_shot_2019-06-19_at_4.25.59_pm.png
