### PR TITLE
Magazine archives updates

### DIFF
--- a/packages/common/components/magazine-issue/item.marko
+++ b/packages/common/components/magazine-issue/item.marko
@@ -44,13 +44,16 @@ $ const imageLinkAttrs = { title, ...input.imageLinkAttrs };
   </if>
   <@footer-left|{ block }|>
     <if(input.withFooter)>
+<<<<<<< HEAD
       <cms-link-element class="btn item__button" to=publication path="subscribeUrl" block=block>Subscribe</cms-link-element>
       <cms-link-element class="btn item__button" to=issue path="digitalEditionUrl" block=block>Digital Edition</cms-link-element>
     </if>
   </@footer-left>
   <@footer-right>
     <if(input.withFooter)>
+=======
+>>>>>>> Removed extra links from magazine archive issue blocks
       <cms-date-element obj=issue field="mailed" />
     </if>
-  </@footer-right>
+  </@footer-left>
 </endeavor-item>

--- a/packages/common/components/magazine-issue/item.marko
+++ b/packages/common/components/magazine-issue/item.marko
@@ -44,15 +44,6 @@ $ const imageLinkAttrs = { title, ...input.imageLinkAttrs };
   </if>
   <@footer-left|{ block }|>
     <if(input.withFooter)>
-<<<<<<< HEAD
-      <cms-link-element class="btn item__button" to=publication path="subscribeUrl" block=block>Subscribe</cms-link-element>
-      <cms-link-element class="btn item__button" to=issue path="digitalEditionUrl" block=block>Digital Edition</cms-link-element>
-    </if>
-  </@footer-left>
-  <@footer-right>
-    <if(input.withFooter)>
-=======
->>>>>>> Removed extra links from magazine archive issue blocks
       <cms-date-element obj=issue field="mailed" />
     </if>
   </@footer-left>

--- a/packages/common/components/magazine/blocks/query-active-issues.marko
+++ b/packages/common/components/magazine/blocks/query-active-issues.marko
@@ -8,7 +8,7 @@ $ const { publicationId } = getAsObject(input, 'query');
 $ const block = 'magazine-active-issues';
 $ const query = {
   publicationId,
-  limit: 10,
+  limit: 12,
   ...input.query,
   queryFragment,
 };
@@ -49,11 +49,6 @@ $ const adCardInput = {
             modifiers=["card"]
           />
         </div>
-        <if(index === 1 || index === 6)>
-          <div class=`${block}__col`>
-            <endeavor-gam-ad-unit-define-display ...adCardInput/>
-          </div>
-        </if>
       </for>
     </div>
   </div>

--- a/packages/common/components/magazine/blocks/query-active-issues.marko
+++ b/packages/common/components/magazine/blocks/query-active-issues.marko
@@ -47,6 +47,7 @@ $ const adCardInput = {
             image-options={ w: 630, h: 840, fit: "crop", crop: "focalpoint", fpX: 0.5, fpY: 0.5 }
             image-position="top"
             modifiers=["card"]
+            with-header=false
           />
         </div>
       </for>

--- a/packages/themes/pennwell/styles/components/magazine/_query-active-issues.scss
+++ b/packages/themes/pennwell/styles/components/magazine/_query-active-issues.scss
@@ -2,11 +2,14 @@
   &__col {
     margin-bottom: map-get($spacers, block);
     @include make-col-ready();
-    @include media-breakpoint-up(md) {
+    @include media-breakpoint-up(sm) {
       @include make-col(6);
     }
-    @include media-breakpoint-up(lg) {
+    @include media-breakpoint-up(md) {
       @include make-col(4);
+    }
+    @include media-breakpoint-up(lg) {
+      @include make-col(3);
     }
   }
   &__col-ad {

--- a/sites/aquamagazine/server/templates/magazine/publication.marko
+++ b/sites/aquamagazine/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/athleticbusiness/server/templates/magazine/publication.marko
+++ b/sites/athleticbusiness/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/automationworld/server/templates/magazine/publication.marko
+++ b/sites/automationworld/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/bioopticsworld/server/templates/magazine/publication.marko
+++ b/sites/bioopticsworld/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/broadbandtechreport/server/templates/magazine/publication.marko
+++ b/sites/broadbandtechreport/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/cablinginstall/server/templates/magazine/publication.marko
+++ b/sites/cablinginstall/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/clevescene/server/templates/magazine/publication.marko
+++ b/sites/clevescene/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/dentaleconomics/server/templates/magazine/publication.marko
+++ b/sites/dentaleconomics/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/dentistryiq/server/templates/magazine/publication.marko
+++ b/sites/dentistryiq/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/evaluationengineering/server/templates/magazine/publication.marko
+++ b/sites/evaluationengineering/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
       ads={

--- a/sites/forconstructionpros/server/templates/magazine/publication.marko
+++ b/sites/forconstructionpros/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/healthcarepackaging/server/templates/magazine/publication.marko
+++ b/sites/healthcarepackaging/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/industrial-lasers/server/templates/magazine/publication.marko
+++ b/sites/industrial-lasers/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/intelligent-aerospace/server/templates/magazine/publication.marko
+++ b/sites/intelligent-aerospace/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/laserfocusworld/server/templates/magazine/publication.marko
+++ b/sites/laserfocusworld/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/ledsmagazine/server/templates/magazine/publication.marko
+++ b/sites/ledsmagazine/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/lightwaveonline/server/templates/magazine/publication.marko
+++ b/sites/lightwaveonline/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/metrotimes/server/templates/magazine/publication.marko
+++ b/sites/metrotimes/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/militaryaerospace/server/templates/magazine/publication.marko
+++ b/sites/militaryaerospace/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/mundopmmi/server/templates/magazine/publication.marko
+++ b/sites/mundopmmi/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/oemmagazine/server/templates/magazine/publication.marko
+++ b/sites/oemmagazine/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/officer/server/templates/magazine/publication.marko
+++ b/sites/officer/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
       ads={

--- a/sites/offshore-mag/server/templates/magazine/publication.marko
+++ b/sites/offshore-mag/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/ogj/config/site.js
+++ b/sites/ogj/config/site.js
@@ -54,7 +54,7 @@ module.exports = {
   menuItems: {
     resources: [
       { href: '/magazine', label: 'Magazine' },
-      { href: '/past-issues', label: 'Past Issues' },
+      { href: '/magazine/5ca3d91475a2545c040041a9', label: 'Past Issues' },
       { href: '/videos', label: 'Videos' },
       { href: '/white-papers', label: 'White Papers' },
       { href: '/webcasts', label: 'Webcasts' },

--- a/sites/ogj/server/templates/magazine/publication.marko
+++ b/sites/ogj/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/orlandoweekly/server/templates/magazine/publication.marko
+++ b/sites/orlandoweekly/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/outinsa/server/templates/magazine/publication.marko
+++ b/sites/outinsa/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/outinstl/server/templates/magazine/publication.marko
+++ b/sites/outinstl/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/packworld/server/templates/magazine/publication.marko
+++ b/sites/packworld/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/plasticsmachinerymagazine/server/templates/magazine/publication.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
       ads={

--- a/sites/profoodworld/server/templates/magazine/publication.marko
+++ b/sites/profoodworld/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/rdhmag/server/templates/magazine/publication.marko
+++ b/sites/rdhmag/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/riverfronttimes/server/templates/magazine/publication.marko
+++ b/sites/riverfronttimes/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/sacurrent/server/templates/magazine/publication.marko
+++ b/sites/sacurrent/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/strategies-u/server/templates/magazine/publication.marko
+++ b/sites/strategies-u/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/utilityproducts/server/templates/magazine/publication.marko
+++ b/sites/utilityproducts/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/vision-systems/server/templates/magazine/publication.marko
+++ b/sites/vision-systems/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/waterworld/server/templates/magazine/publication.marko
+++ b/sites/waterworld/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />

--- a/sites/woodfloorbusiness/server/templates/magazine/publication.marko
+++ b/sites/woodfloorbusiness/server/templates/magazine/publication.marko
@@ -19,7 +19,7 @@ $ const publication = getAsObject(data, 'publication');
         <div class="page-wrapper__header">
           <endeavor-breadcrumbs-magazine target=publication />
           <h1 class="page-wrapper__title">
-            ${publication.name}
+            ${publication.name} Archives
           </h1>
           <if(publication.description)>
             <p class="page-wrapper__description">
@@ -32,9 +32,6 @@ $ const publication = getAsObject(data, 'publication');
   </div>
 
   <@below-container>
-    <endeavor-load-more-header>
-      Recent Issues
-    </endeavor-load-more-header>
     <endeavor-magazine-block-query-active-issues
       query={ publicationId: publication.id }
     />


### PR DESCRIPTION
- Corrected "Past Issues" alias for OGJ
- Added " Archives" suffix to magazine archives page for clarity
- Updated archives to have 4 columns at desktop resolution
- Removed unneeded links (Subscribe, etc) from archives issue cards
- Dropped in-line ads from archives page
- Dropped header from archives issue cards

![Screen Shot 2019-06-20 at 11 22 17 AM](https://user-images.githubusercontent.com/2855198/59865045-bb8f3400-934d-11e9-9992-df1c0cef489a.png)
