### PR TITLE
Rework IdentityX content access

### DIFF
--- a/packages/common/components/content/blocks/page-body.marko
+++ b/packages/common/components/content/blocks/page-body.marko
@@ -3,29 +3,37 @@ import { getAsObject, getAsArray } from '@base-cms/object-path';
 $ const { req } = out.global;
 $ const content = getAsObject(input, 'content');
 
-$ const { isRequired: requiresReg, accessLevels } = getAsObject(content, 'userRegistration');
+$ const { isRequired: requiresReg, accessLevels: accessLevelIds } = getAsObject(content, 'userRegistration');
 
-<div class="page-wrapper__body">
-  <endeavor-content-block-primary-media content=content />
-  <endeavor-content-block-contact-details content=content />
-  <identity-x|{ lacksRequiredAccess, needsLoginForm }| enabled=requiresReg required-access-levels=accessLevels>
-    <if(needsLoginForm)>
-      <!-- @todo Allow this text to be modified / child-rendered -->
-      <p>You must be logged-in to access this content.</p>
-      <cms-browser-component name="IdentitySignInForm" />
+<identity-x-access|context| enabled=requiresReg required-access-level-ids=accessLevelIds>
+  $ const {
+    canAccess,
+    isLoggedIn,
+    requiresAccessLevel,
+    hasRequiredAccessLevel,
+    messages,
+  } = context;
+
+  <div class="page-wrapper__body">
+    <endeavor-content-block-primary-media content=content />
+    <endeavor-content-block-contact-details content=content />
+    <if(!canAccess)>
+      <if(isLoggedIn && !hasRequiredAccessLevel)>
+        $!{messages.loggedInNoAccess}
+      </if>
+      <else-if(!isLoggedIn && requiresAccessLevel)>
+        $!{messages.loggedOutNoAccess}
+      </else-if>
+      <else-if(!isLoggedIn)>
+        <h5>You must be logged-in to access this content.</h5>
+        <cms-browser-component name="IdentitySignInForm" />
+      </else-if>
     </if>
-    <else-if(lacksRequiredAccess)>
-      <!-- @todo Display required access levels -->
-      <!-- @todo Allow this text to be modified / child-rendered -->
-      <p>Your user account does not have access to this content. Please contact support to upgrade your access level.</p>
-    </else-if>
-  </identity-x>
-</div>
+  </div>
 
-<div class="page-wrapper__contents">
-  <identity-x|{ canDisplayContent }| enabled=requiresReg required-access-levels=accessLevels>
-    <if(canDisplayContent)>
+  <div class="page-wrapper__contents">
+    <if(canAccess)>
       <endeavor-content-block-page-body-contents content=content />
     </if>
-  </identity-x>
-</div>
+  </div>
+</identity-x-access>

--- a/packages/identity-x/api/queries/check-content-access.js
+++ b/packages/identity-x/api/queries/check-content-access.js
@@ -1,0 +1,19 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+query CheckContentAccess($input: CheckContentAccessQueryInput!) {
+  checkContentAccess(input: $input) {
+    canAccess
+    isLoggedIn
+    hasRequiredAccessLevel
+    requiresAccessLevel
+    requiredAccessLevels {
+      id
+      name
+    }
+    messages
+  }
+}
+
+`;

--- a/packages/identity-x/components/access.marko
+++ b/packages/identity-x/components/access.marko
@@ -1,0 +1,35 @@
+import { getAsArray } from '@base-cms/object-path'
+
+$ const { req, onAsyncBlockError } = out.global;
+$ const isDevelopment = process.env.NODE_ENV === 'development';
+$ const { identityX } = req;
+
+$ const requiredAccessLevelIds = getAsArray(input.requiredAccessLevelIds);
+$ const params = { isEnabled: input.enabled, requiredAccessLevelIds };
+
+$ const checkContentAccess = async () => (Boolean(req.identityX) ? identityX.checkContentAccess(params) : {
+  canAccess: true,
+  isLoggedIn: false,
+  hasRequiredAccessLevel: false,
+  requiresAccessLevel: false,
+  requiredAccessLevels: [],
+  messages: {},
+});
+
+<await(checkContentAccess())>
+  <@then|access|>
+    <${input.renderBody} ...access />
+  </@then>
+  <@catch|err|>
+    $ if (typeof onAsyncBlockError === 'function') onAsyncBlockError(err);
+    <if(input.onError)>
+      <${input.onError} err=err />
+    </if>
+    <else>
+      <pre>An unexpected error occurred: ${err.message}</pre>
+      <if(isDevelopment)>
+        <pre>${err.stack}</pre>
+      </if>
+    </else>
+  </@catch>
+</await>

--- a/packages/identity-x/components/index.marko
+++ b/packages/identity-x/components/index.marko
@@ -1,6 +1,6 @@
 import { getAsArray } from '@base-cms/object-path'
 
-$ const { site, req, onAsyncBlockError } = out.global;
+$ const { req, onAsyncBlockError } = out.global;
 $ const isDevelopment = process.env.NODE_ENV === 'development';
 $ const { identityX } = req;
 $ const isEnabled = Boolean(req.identityX) && input.enabled;

--- a/packages/identity-x/components/index.marko
+++ b/packages/identity-x/components/index.marko
@@ -12,35 +12,11 @@ $ const loadContext = async () => (isEnabled ? identityX.loadActiveContext() : {
   hasUser: false,
 });
 
-
-$ const requiredAccessLevels = getAsArray(input, 'requiredAccessLevels');
-$ const requiresAccessLevel = isEnabled ? Boolean(requiredAccessLevels.length) : false;
-$ const canDisplayContent = (hasAccessLevel, { hasUser, hasTeams }) => {
-  if (!isEnabled) return true;
-  if (requiresAccessLevel && !hasAccessLevel) return false;
-  return hasUser || hasTeams;
-};
-$ const lacksRequiredAccess = (hasAccessLevel) => {
-  if (!isEnabled) return false;
-  return requiresAccessLevel && !hasAccessLevel;
-};
-$ const needsLoginForm = ({ hasUser, hasTeams }) => {
-  if (!isEnabled) return false;
-  return !hasUser && !hasTeams
-};
-
 <await(loadContext())>
   <@then|context|>
-    $ const accessLevelIds = context.mergedAccessLevels.map(level => level.id);
-    $ const hasAccessLevel = requiredAccessLevels.some(id => accessLevelIds.includes(id));
     $ const output = {
       ...context,
       isEnabled,
-      requiresAccessLevel,
-      hasAccessLevel,
-      lacksRequiredAccess: lacksRequiredAccess(hasAccessLevel),
-      needsLoginForm: needsLoginForm(context),
-      canDisplayContent: canDisplayContent(hasAccessLevel, context),
     };
     <${input.renderBody} ...output />
   </@then>

--- a/packages/identity-x/components/marko.json
+++ b/packages/identity-x/components/marko.json
@@ -10,6 +10,17 @@
       "@required-access-levels": {
         "type": "array"
       }
+    },
+    "identity-x-access": {
+      "template": "./access",
+      "<on-error>": {},
+      "@enabled": {
+        "type": "boolean",
+        "default-value": true
+      },
+      "@required-access-level-ids": {
+        "type": "array"
+      }
     }
   }
 }

--- a/packages/identity-x/components/marko.json
+++ b/packages/identity-x/components/marko.json
@@ -6,9 +6,6 @@
       "@enabled": {
         "type": "boolean",
         "default-value": true
-      },
-      "@required-access-levels": {
-        "type": "array"
       }
     },
     "identity-x-access": {

--- a/packages/identity-x/service.js
+++ b/packages/identity-x/service.js
@@ -1,5 +1,6 @@
 const createClient = require('./create-client');
 const getActiveContext = require('./api/queries/get-active-context');
+const checkContentAccess = require('./api/queries/check-content-access');
 const tokenCookie = require('./utils/token-cookie');
 
 class IdentityX {
@@ -25,17 +26,17 @@ class IdentityX {
   }
 
   async loadActiveContext() {
-    if (typeof this.activeContext === 'undefined') {
-      try {
-        const { data = {} } = await this.client.query({ query: getActiveContext });
-        this.activeContext = data.activeAppContext || {};
-      } catch (e) {
-        this.activeContext = {};
-        this.token = null;
-        throw e;
-      }
+    if (!this.activeContextQuery) {
+      this.activeContextQuery = this.client.query({ query: getActiveContext });
     }
-    return this.activeContext;
+    const { data = {} } = await this.activeContextQuery;
+    return data.activeAppContext || {};
+  }
+
+  async checkContentAccess(input) {
+    const variables = { input };
+    const { data = {} } = await this.client.query({ query: checkContentAccess, variables });
+    return data.checkContentAccess || {};
   }
 }
 


### PR DESCRIPTION
Requires base-cms/id-me#20 to be merged and in production.

Creates the `<identity-x-access>` component which is responsible for determining content access. The logic for this has been moved to IdentityX natively (instead of within the component itself).  The `<identity-x>` component still exists, but now is used for user/team context only - not for gating.

Messages can now be customized based on user/team context and access level requirements.