### PR TITLE
NativeX "templateless" delivery support

### DIFF
--- a/packages/common/components/content/blocks/item.marko
+++ b/packages/common/components/content/blocks/item.marko
@@ -5,7 +5,7 @@ $ const content = getAsObject(input, 'content');
 $ const primarySection = getAsObject(content, 'primarySection');
 $ const company = getAsObject(content, 'company');
 $ const userRegistration = getAsObject(content, 'userRegistration');
-$ const imageLinkAttrs = { title: content.shortName, ...input.imageLinkAttrs };
+$ const imageLinkAttrs = { title: content.shortName, ...input.imageLinkAttrs, ...input.contentLinkAttrs };
 $ const titleModifiers = getAsArray(input, 'titleModifiers');
 $ if (userRegistration.isRequired && identityX) titleModifiers.push('locked');
 
@@ -16,7 +16,7 @@ $ if (userRegistration.isRequired && identityX) titleModifiers.push('locked');
   <endeavor-content-block-promotion-item ...input />
 </else-if>
 <else>
-  <endeavor-item modifiers=input.modifiers flush=input.flush>
+  <endeavor-item modifiers=input.modifiers flush=input.flush attrs=input.attrs>
     <@image
       display=input.withImage
       height=input.imageHeight
@@ -41,11 +41,11 @@ $ if (userRegistration.isRequired && identityX) titleModifiers.push('locked');
       </if>
     </@header-left>
     <@title tag="h5" modifiers=titleModifiers>
-      <cms-content-short-name tag=null obj=content link=true />
+      <cms-content-short-name tag=null obj=content link=true link-attrs=input.contentLinkAttrs />
     </@title>
     <if(input.withTeaser)>
       <@description tag="p">
-        <cms-content-teaser tag=null obj=content link=true />
+        <cms-content-teaser tag=null obj=content link=true link-attrs=input.contentLinkAttrs />
       </@description>
     </if>
     <@footer-left|{ block }|>

--- a/packages/common/components/content/blocks/marko.json
+++ b/packages/common/components/content/blocks/marko.json
@@ -82,7 +82,9 @@
       "@image-min-height": "number",
       "@image-min-width": "number",
       "@title-modifiers": "array",
-      "@modifiers": "array"
+      "@modifiers": "array",
+      "@attrs": "object",
+      "@content-link-attrs": "object"
     },
     "endeavor-content-nativex-item": {
       "template": "./nativex-item.marko"

--- a/packages/common/components/content/blocks/nativex-item.marko
+++ b/packages/common/components/content/blocks/nativex-item.marko
@@ -1,17 +1,55 @@
 import { getAsObject } from '@base-cms/object-path';
 import { buildImgixUrl } from '@base-cms/image';
+import { useNativeX, convertAdToContent } from '../../../services/native-x';
 
-$ const content = getAsObject(input, 'content');
-$ const primarySection = getAsObject(content, 'primarySection');
-$ const image = getAsObject(content, 'primaryImage');
+$ const { site } = out.global;
 
-<endeavor-nativex-placement
-  name=input.placement
-  aliases=input.aliases
-  fallback-vars={
-    url: content.canonicalPath,
-    content: { title: content.shortName, type: content.typeTitled, published: content.publishedDate },
-    image: { src: buildImgixUrl(image.src, input.imageOptions, undefined, image.isLogo), alt: image.alt },
-    section: { name: primarySection.name },
-  }
-/>
+$ const isEnabled = () => useNativeX(site, {
+  name: input.placement,
+  index: input.index,
+  aliases: input.aliases,
+});
+
+$ const itemInput = getAsObject(input, 'item');
+
+<if(input.currentIndex === input.index && isEnabled())>
+  <endeavor-nativex-placement-elements|{ ads }|
+    name=input.placement
+    aliases=input.aliases
+    image-options=itemInput.imageOptions
+  >
+    $ const hasAd = ads && ads.length && ads[0];
+    <if(hasAd)>
+      $ const ad = ads[0];
+      $ const linkAttrs = { target: "_blank", rel: "noopener", ...ad.attributes.link };
+      <if(ad.hasCampaign)>
+        <!-- Campaign found. Convert the ad to a "content object" and append tracking. -->
+        <!-- Note: `image-options` are intentionally reset, as NX handles them directly (see L19) -->
+        $ const content = convertAdToContent(ad);
+        <endeavor-content-block-item
+          ...itemInput
+          attrs=ad.attributes.container
+          content-link-attrs=linkAttrs
+          content=content
+          image-options={}
+        />
+      </if>
+      <else>
+        <!-- No campaign was found. Append fallback tracking to content item -->
+        <endeavor-content-block-item
+          ...itemInput
+          attrs=ad.attributes.container
+          content-link-attrs=ad.attributes.link
+        />
+      </else>
+    </if>
+    <else>
+      <!-- No ad data was returned. Display the regular content item. -->
+      <endeavor-content-block-item ...itemInput />
+    </else>
+  </endeavor-nativex-placement-elements>
+</if>
+<else>
+  <!-- This position is not eligible for an ad. Display the regular content item. -->
+  <endeavor-content-block-item ...itemInput />
+</else>

--- a/packages/common/components/content/blocks/query-feed.marko
+++ b/packages/common/components/content/blocks/query-feed.marko
@@ -21,7 +21,7 @@ $ const nativeXEnabled = useNativeX(site, {
 $ const imageOptions = { w: 120, h: 120, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 };
 $ const withImage = input.withImage === undefined ? true : Boolean(input.withImage);
 $ const withSection = input.withSection === undefined ? true : Boolean(input.withSection);
-$ const usePlaceholder = input.usePlaceholder === undefined ? true : Boolean(input.usePlaceholder);
+$ const imageUsePlaceholder = input.usePlaceholder === undefined ? true : Boolean(input.usePlaceholder);
 
 <cms-query-website-scheduled-content|{ nodes, pageInfo }| ...params>
   $ const listNodes = asArray(nodes);
@@ -34,26 +34,22 @@ $ const usePlaceholder = input.usePlaceholder === undefined ? true : Boolean(inp
           </@header>
         </if>
         <@item|{ item, index }|>
-          <if(nativeXEnabled && index === nativeX.index)>
-            <endeavor-content-nativex-item
-              placement=nativeX.placement
-              aliases=nativeX.aliases
-              content=item
-              image-options=imageOptions
-            />
-          </if>
-          <else>
-            <endeavor-content-block-item
-              content=item
-              image-position="right"
-              image-options=imageOptions
-              image-width=75
-              image-height=75
-              with-image=withImage
-              with-section=withSection
-              image-use-placeholder=usePlaceholder
-            />
-          </else>
+          <endeavor-content-nativex-item
+            placement=nativeX.placement
+            aliases=nativeX.aliases
+            index=nativeX.index
+            current-index=index
+            item={
+              content: item,
+              imageHeight: 75,
+              imageOptions,
+              imagePosition: "right",
+              imageUsePlaceholder,
+              imageWidth: 75,
+              withImage,
+              withSection,
+            }
+          />
         </@item>
       </endeavor-item-list>
     </div>

--- a/packages/common/components/content/blocks/query-hero.marko
+++ b/packages/common/components/content/blocks/query-hero.marko
@@ -2,7 +2,6 @@ import { asArray, asObject } from '@base-cms/utils';
 import { getAsObject } from '@base-cms/object-path';
 import { buildImgixUrl } from '@base-cms/image';
 import contentListFragment from '../../../api/fragments/content-list';
-import { useNativeX } from '../../../services/native-x';
 
 $ const { site } = out.global;
 $ const block = 'content-query-hero';
@@ -13,11 +12,6 @@ $ const params = {
   queryName: 'QueryHero',
 };
 $ const nativeX = getAsObject(input, 'nativeX');
-$ const nativeXEnabled = useNativeX(site, {
-  name: nativeX.placement,
-  index: nativeX.index,
-  aliases: nativeX.aliases,
-});
 $ const listImageOptions = { w: 120, h: 120, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 };
 
 <cms-query-website-scheduled-content|{ nodes }| ...params>
@@ -43,23 +37,19 @@ $ const listImageOptions = { w: 120, h: 120, fit: 'crop', crop: 'focalpoint', fp
         <div class=`${block}__list`>
           <endeavor-item-list flush=true card=true items=listNodes>
             <@item|{ item, index }|>
-              <if(nativeXEnabled && index === nativeX.index)>
-                <endeavor-content-nativex-item
-                  placement=nativeX.placement
-                  aliases=nativeX.aliases
-                  content=item
-                  image-options=listImageOptions
-                />
-              </if>
-              <else>
-                <endeavor-content-block-item
-                  content=item
-                  image-position="right"
-                  image-options=listImageOptions
-                  image-width=75
-                  image-height=75
-                />
-              </else>
+              <endeavor-content-nativex-item
+                placement=nativeX.placement
+                aliases=nativeX.aliases
+                index=nativeX.index
+                current-index=index
+                item={
+                  content: item,
+                  imageHeight: 75,
+                  imageOptions: listImageOptions,
+                  imagePosition: "right",
+                  imageWidth: 75,
+                }
+              />
             </@item>
           </endeavor-item-list>
         </div>

--- a/packages/common/components/content/blocks/query-load-more.marko
+++ b/packages/common/components/content/blocks/query-load-more.marko
@@ -1,7 +1,6 @@
 import { getAsObject, getAsArray } from '@base-cms/object-path';
 import { asArray, asObject } from '@base-cms/utils';
 import contentListFragment from '../../../api/fragments/content-list';
-import { useNativeX } from '../../../services/native-x';
 
 $ const { site } = out.global;
 $ const pageNumber = input.pageNumber || 1;
@@ -31,11 +30,6 @@ $ const adListInput = {
   ...getAsObject(input, 'ads.list'),
 };
 $ const nativeX = getAsObject(input, 'nativeX');
-$ const nativeXEnabled = useNativeX(site, {
-  name: nativeX.placement,
-  index: nativeX.index,
-  aliases: nativeX.aliases,
-});
 $ const imageOptions = { w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0.5, fpY: 0.5 };
 
 <cms-query-website-scheduled-content|{ nodes, pageInfo }| ...query>
@@ -53,23 +47,19 @@ $ const imageOptions = { w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0
         <div class="row">
           <for|content, index| of=cardNodes>
             <div class=`${block}__col`>
-              <if(nativeXEnabled && index === nativeX.index)>
-                <endeavor-content-nativex-item
-                  placement=nativeX.placement
-                  aliases=nativeX.aliases
-                  content=content
-                  image-options=imageOptions
-                />
-              </if>
-              <else>
-                <endeavor-content-block-item
-                  content=content
-                  image-modifiers=["fluid", "21by9"]
-                  image-options=imageOptions
-                  image-position="top"
-                  modifiers=["card"]
-                />
-              </else>
+              <endeavor-content-nativex-item
+                placement=nativeX.placement
+                aliases=nativeX.aliases
+                index=nativeX.index
+                current-index=index
+                item={
+                  content,
+                  imageModifiers: ["fluid", "21by9"],
+                  imageOptions,
+                  imagePosition: "top",
+                  modifiers: ["card"]
+                }
+              />
             </div>
             <if(index === 1 || index === 6)>
               <div class=`${block}__col`>

--- a/packages/common/components/content/blocks/query-related.marko
+++ b/packages/common/components/content/blocks/query-related.marko
@@ -1,7 +1,6 @@
 import { getAsObject } from '@base-cms/object-path';
 import { buildImgixUrl } from '@base-cms/image';
 import contentListFragment from '../../../api/fragments/content-list';
-import { useNativeX } from '../../../services/native-x';
 
 $ const { site } = out.global;
 $ const block = 'content-query-related';
@@ -13,11 +12,6 @@ $ const params = {
 };
 $ const header = input.header || 'Related Content';
 $ const nativeX = getAsObject(input, 'nativeX');
-$ const nativeXEnabled = useNativeX(site, {
-  name: nativeX.placement,
-  index: nativeX.index,
-  aliases: nativeX.aliases,
-});
 $ const imageOptions = { w: 120, h: 120, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 };
 
 <cms-query-website-scheduled-content|{ nodes }| ...params>
@@ -30,23 +24,19 @@ $ const imageOptions = { w: 120, h: 120, fit: 'crop', crop: 'focalpoint', fpX: 0
           </@header>
         </if>
         <@item|{ item, index }|>
-          <if(nativeXEnabled && index === nativeX.index)>
-            <endeavor-content-nativex-item
-              placement=nativeX.placement
-              aliases=nativeX.aliases
-              content=item
-              image-options=imageOptions
-            />
-          </if>
-          <else>
-            <endeavor-content-block-item
-              content=item
-              image-position="right"
-              image-options=imageOptions
-              image-width=75
-              image-height=75
-            />
-          </else>
+          <endeavor-content-nativex-item
+            placement=nativeX.placement
+            aliases=nativeX.aliases
+            index=nativeX.index
+            current-index=index
+            item={
+              content: item,
+              imageHeight: 75,
+              imageOptions,
+              imagePosition: "right",
+              imageWidth: 75,
+            }
+          />
         </@item>
       </endeavor-item-list>
     </div>

--- a/packages/common/components/content/blocks/query-section-list.marko
+++ b/packages/common/components/content/blocks/query-section-list.marko
@@ -1,7 +1,6 @@
 import { getAsObject } from '@base-cms/object-path';
 import { buildImgixUrl } from '@base-cms/image';
 import contentListFragment from '../../../api/fragments/content-list';
-import { useNativeX } from '../../../services/native-x';
 
 $ const { site } = out.global;
 $ const block = 'content-query-section-list';
@@ -13,18 +12,13 @@ $ const params = {
   queryName: 'QuerySectionList',
 };
 $ const nativeX = getAsObject(input, 'nativeX');
-$ const nativeXEnabled = useNativeX(site, {
-  name: nativeX.placement,
-  index: nativeX.index,
-  aliases: nativeX.aliases,
-});
 $ const imageOptions = { w: 120, h: 120, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 };
 $ const header = getAsObject(input, 'header');
 $ const description = getAsObject(input, 'description');
 $ const footer = getAsObject(input, 'footer');
 $ const withImage = input.withImage === undefined ? true : Boolean(input.withImage);
 $ const withSection = input.withSection === undefined ? true : Boolean(input.withSection);
-$ const usePlaceholder = input.usePlaceholder === undefined ? true : Boolean(input.usePlaceholder);
+$ const imageUsePlaceholder = input.usePlaceholder === undefined ? true : Boolean(input.usePlaceholder);
 
 <cms-query-website-scheduled-content|{ nodes }| ...params>
   <if(nodes.length)>
@@ -40,26 +34,22 @@ $ const usePlaceholder = input.usePlaceholder === undefined ? true : Boolean(inp
         </@description>
       </if>
       <@item|{ item, index }|>
-        <if(nativeXEnabled && index === nativeX.index)>
-          <endeavor-content-nativex-item
-            placement=nativeX.placement
-            aliases=nativeX.aliases
-            content=item
-            image-options=imageOptions
-          />
-        </if>
-        <else>
-          <endeavor-content-block-item
-            content=item
-            with-image=withImage
-            with-section=withSection
-            image-use-placeholder=usePlaceholder
-            image-position="right"
-            image-options=imageOptions
-            image-width=75
-            image-height=75
-          />
-        </else>
+        <endeavor-content-nativex-item
+          placement=nativeX.placement
+          aliases=nativeX.aliases
+          index=nativeX.index
+          current-index=index
+          item={
+            content: item,
+            imageHeight: 75,
+            imageOptions,
+            imagePosition: "right",
+            imageUsePlaceholder,
+            imageWidth: 75,
+            withImage,
+            withSection,
+          }
+        />
       </@item>
       <if(footer.value)>
         <@footer href=footer.href target=footer.target>

--- a/packages/common/components/item/components/image.marko
+++ b/packages/common/components/item/components/image.marko
@@ -26,6 +26,7 @@ $ if (input.minWidth) placeholderStyle.push(`min-width: ${input.minWidth}px;`);
         lazyload=input.lazyload
         link-attrs=input.linkAttrs
         link-to=input.linkTo
+        link-path=input.linkPath
         obj=image
         options=input.options
         width=input.width

--- a/packages/common/components/item/item.marko
+++ b/packages/common/components/item/item.marko
@@ -23,7 +23,7 @@ $ if (image.position) modifiers.push(`image-${image.position}`);
 $ if (input.flush) modifiers.push('flush');
 $ const classNames = [block, ...modifiers.map(mod => `${block}--${mod}`)];
 
-<${input.tag} class=classNames>
+<${input.tag} class=classNames ...input.attrs>
   <if(image.display)>
     <image
       alt=image.alt
@@ -32,6 +32,7 @@ $ const classNames = [block, ...modifiers.map(mod => `${block}--${mod}`)];
       image=image.image
       lazyload=image.lazyload
       link-attrs=image.linkAttrs
+      link-path=image.linkPath
       link-to=image.linkTo
       min-height=image.minHeight
       min-width=image.minWidth

--- a/packages/common/components/item/marko.json
+++ b/packages/common/components/item/marko.json
@@ -10,6 +10,7 @@
         },
         "@image": "object",
         "@link-attrs": "object",
+        "@link-path": "string",
         "@link-to": "object",
         "@height": "number",
         "@lazyload": {
@@ -55,6 +56,7 @@
       "@header-modifiers": "array",
       "@footer-modifiers": "array",
       "@modifiers": "array",
+      "@attrs": "object",
       "@flush": {
         "type": "boolean",
         "default-value": false

--- a/packages/common/components/native-x/init.marko
+++ b/packages/common/components/native-x/init.marko
@@ -1,4 +1,4 @@
-import { isInitable, getURI } from '../../services/native-x';
+import { isInitable, getTrackingURI } from '../../services/native-x';
 
 $ const { site } = out.global;
 
@@ -11,7 +11,7 @@ $ const { site } = out.global;
       m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; a.crossOrigin = 'anonymous'; m.parentNode.insertBefore(a, m)
     })(window, document, 'script', 'https://d24bnj4f1s1f8m.cloudfront.net/1.0.0-rc.4.3/fortnight.min.js', 'fortnight');
     fortnight('init', {
-      domain: '${getURI(site)}'
+      domain: '${getTrackingURI(site)}'
     });
   </script>
 </if>

--- a/packages/common/components/native-x/marko.json
+++ b/packages/common/components/native-x/marko.json
@@ -5,6 +5,9 @@
     },
     "endeavor-nativex-init": {
       "template": "./init.marko"
+    },
+    "endeavor-nativex-placement-elements": {
+      "template": "./placement-elements.marko"
     }
   }
 }

--- a/packages/common/components/native-x/placement-elements.marko
+++ b/packages/common/components/native-x/placement-elements.marko
@@ -1,0 +1,33 @@
+import { retrieveElements, isEnabled, getPlacementId, getURI } from '../../services/native-x';
+
+$ const { site, onAsyncBlockError } = out.global;
+$ const isDevelopment = process.env.NODE_ENV === 'development';
+$ const { name, aliases } = input;
+
+$ const args = {
+  uri: getURI(site),
+  placementId: getPlacementId(site, { name, aliases }),
+  opts: {
+    image: input.imageOptions,
+  },
+};
+
+<if(isEnabled(site, { name, aliases }))>
+  <await(retrieveElements(args))>
+    <@then|{ ads }|>
+      <${input.renderBody} ads=ads />
+    </@then>
+    <@catch|err|>
+      $ if (typeof onAsyncBlockError === 'function') onAsyncBlockError(err);
+      <if(input.onError)>
+        <${input.onError} err=err />
+      </if>
+      <else>
+        <pre>An unexpected error occurred: ${err.message}</pre>
+        <if(isDevelopment)>
+          <pre>${err.stack}</pre>
+        </if>
+      </else>
+    </@catch>
+  </await>
+</if>

--- a/packages/common/components/native-x/placement-elements.marko
+++ b/packages/common/components/native-x/placement-elements.marko
@@ -1,6 +1,6 @@
 import { retrieveElements, isEnabled, getPlacementId, getURI } from '../../services/native-x';
 
-$ const { site, onAsyncBlockError } = out.global;
+$ const { site, onAsyncBlockError, req } = out.global;
 $ const isDevelopment = process.env.NODE_ENV === 'development';
 $ const { name, aliases } = input;
 
@@ -10,6 +10,7 @@ $ const args = {
   opts: {
     image: input.imageOptions,
   },
+  req,
 };
 
 <if(isEnabled(site, { name, aliases }))>

--- a/packages/common/components/native-x/placement.marko
+++ b/packages/common/components/native-x/placement.marko
@@ -1,6 +1,6 @@
 import { retrieve, isEnabled, getPlacementId, getURI } from '../../services/native-x';
 
-$ const { site, onAsyncBlockError } = out.global;
+$ const { site, onAsyncBlockError, req } = out.global;
 $ const isDevelopment = process.env.NODE_ENV === 'development';
 $ const { name, aliases } = input;
 
@@ -10,6 +10,7 @@ $ const args = {
   opts: {
     fv: input.fallbackVars,
   },
+  req,
 };
 
 <if(isEnabled(site, { name, aliases }))>

--- a/packages/common/services/native-x.js
+++ b/packages/common/services/native-x.js
@@ -55,7 +55,33 @@ const hasIndex = index => typeof index !== 'undefined' && index !== null && inde
 const useNativeX = (config, { name, index, aliases }) => isEnabled(config, { name, aliases })
   && hasIndex(index);
 
+const convertAdToContent = (ad) => {
+  const { campaign, creative, image } = ad;
+  return {
+    id: campaign.id,
+    shortName: creative.title,
+    typeTitled: 'Text Ad',
+    type: 'text-ad',
+    teaser: creative.teaser,
+    published: campaign.createdAt,
+    canonicalPath: ad.href,
+    primaryImage: {
+      id: image.id,
+      alt: creative.title,
+      src: image.src,
+      __typename: 'AssetImage',
+    },
+    primarySection: {
+      name: 'Sponsored',
+      fullName: 'Sponsored',
+      __typename: 'WebsiteSection',
+    },
+    __typename: 'ContentTextAd',
+  };
+};
+
 module.exports = {
+  convertAdToContent,
   isEnabled,
   isInitable,
   getPlacementId,

--- a/packages/common/services/native-x.js
+++ b/packages/common/services/native-x.js
@@ -1,10 +1,23 @@
 const { isObject, asArray } = require('@base-cms/utils');
 const fetch = require('node-fetch');
 
-const retrieve = async ({ uri, placementId, opts }) => {
+const createHeaders = ({ req }) => {
+  if (!req) return {};
+  return {
+    'x-forwarded-for': req.ip,
+    'user-agent': req.get('user-agent'),
+  };
+};
+
+const retrieve = async ({
+  uri,
+  placementId,
+  opts,
+  req,
+}) => {
   const query = isObject(opts) ? `?opts=${encodeURIComponent(JSON.stringify(opts))}` : '';
   const url = `${uri}/placement/${placementId}.html${query}`;
-  const response = await fetch(url);
+  const response = await fetch(url, { headers: createHeaders({ req }) });
   if (!response.ok) {
     const err = new Error(response.statusMessage);
     err.statusCode = response.statusText;
@@ -13,10 +26,15 @@ const retrieve = async ({ uri, placementId, opts }) => {
   return response.text();
 };
 
-const retrieveElements = async ({ uri, placementId, opts }) => {
+const retrieveElements = async ({
+  uri,
+  placementId,
+  opts,
+  req,
+}) => {
   const query = isObject(opts) ? `?opts=${encodeURIComponent(JSON.stringify(opts))}` : '';
   const url = `${uri}/placement/elements/${placementId}.json${query}`;
-  const response = await fetch(url);
+  const response = await fetch(url, { headers: createHeaders({ req }) });
   if (!response.ok) {
     const err = new Error(response.statusMessage);
     err.statusCode = response.statusText;

--- a/packages/common/services/native-x.js
+++ b/packages/common/services/native-x.js
@@ -15,6 +15,8 @@ const retrieve = async ({ uri, placementId, opts }) => {
 
 const getURI = site => site.get('nativeX.uri');
 
+const getTrackingURI = site => site.get('nativeX.trackingUri', getURI(site));
+
 const getPlacementId = (config, { name, aliases }) => {
   const prefix = 'nativeX.placements';
   const defaultId = config.get(`${prefix}.default.${name}.id`);
@@ -46,5 +48,6 @@ module.exports = {
   getPlacementId,
   useNativeX,
   retrieve,
+  getTrackingURI,
   getURI,
 };

--- a/packages/common/services/native-x.js
+++ b/packages/common/services/native-x.js
@@ -13,6 +13,19 @@ const retrieve = async ({ uri, placementId, opts }) => {
   return response.text();
 };
 
+const retrieveElements = async ({ uri, placementId, opts }) => {
+  const query = isObject(opts) ? `?opts=${encodeURIComponent(JSON.stringify(opts))}` : '';
+  const url = `${uri}/placement/elements/${placementId}.json${query}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    const err = new Error(response.statusMessage);
+    console.log(response);
+    err.statusCode = response.statusText;
+    throw err;
+  }
+  return response.json();
+};
+
 const getURI = site => site.get('nativeX.uri');
 
 const getTrackingURI = site => site.get('nativeX.trackingUri', getURI(site));
@@ -48,6 +61,7 @@ module.exports = {
   getPlacementId,
   useNativeX,
   retrieve,
+  retrieveElements,
   getTrackingURI,
   getURI,
 };

--- a/packages/common/services/native-x.js
+++ b/packages/common/services/native-x.js
@@ -19,7 +19,6 @@ const retrieveElements = async ({ uri, placementId, opts }) => {
   const response = await fetch(url);
   if (!response.ok) {
     const err = new Error(response.statusMessage);
-    console.log(response);
     err.statusCode = response.statusText;
     throw err;
   }


### PR DESCRIPTION
NativeX ad/fallback templates will now be rendered directly by the website. This ensures display consistency with other content items (and fixes various display issues) without having to update/manage the placement templates in NativeX itself. 

Requires cygnusb2b/fortnight-graph#178 to be merged and deployed to production _before_ deploying this change. See the aforementioned PR for more info on "templateless" delivery.