### PR TITLE
BC-PIA: main nav only has 5 li, can show on iPad

### DIFF
--- a/sites/perioimplantadvisory/server/styles/_variables.scss
+++ b/sites/perioimplantadvisory/server/styles/_variables.scss
@@ -12,5 +12,5 @@ $theme-site-nav-secondary-type: light;
 
 $theme-site-nav-primary-breakpoints: (
   small-text: 2000px,
-  hide: 1090px,
+  hide: 767px,
 );


### PR DESCRIPTION
https://3.basecamp.com/4053736/buckets/11134315/todos/1884148758

Updated the hide breakpoint so that the main navigation would show on iPads

![Screen Shot 2019-06-25 at 2 17 28 PM](https://user-images.githubusercontent.com/6343242/60126643-11038080-9754-11e9-965a-fb1ffa093079.png)
