### PR TITLE
BC-sponsoredRows

### DIFF
--- a/packages/themes/pennwell/styles/components/_item.scss
+++ b/packages/themes/pennwell/styles/components/_item.scss
@@ -295,6 +295,11 @@
   }
 
   &__content-link {
+    &--company {
+      .item__asset-image {
+        max-width: initial;
+      }
+    }
     &--video {
       &::after {
         position: absolute;


### PR DESCRIPTION
Override max-width setting for asset images inside of company content types.

https://3.basecamp.com/4053736/buckets/11134315/todos/1888994912

Old:
![Screen Shot 2019-06-27 at 11 37 37 AM](https://user-images.githubusercontent.com/6343242/60284045-34533a80-98d0-11e9-90a1-25e6a1a2f222.png)

New:
![Screen Shot 2019-06-27 at 11 35 37 AM](https://user-images.githubusercontent.com/6343242/60284054-3c12df00-98d0-11e9-8746-dc026c0e4b72.png)
