### PR TITLE
BC-companyItems:

### DIFF
--- a/packages/themes/pennwell/styles/components/_item.scss
+++ b/packages/themes/pennwell/styles/components/_item.scss
@@ -103,12 +103,15 @@
   &__footer {
     @include theme-small-text();
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     justify-content: space-between;
     margin-top: auto;
     color: $gray;
     &:empty {
       display: none;
+    }
+    @include media-breakpoint-up("md", $grid-breakpoints) {
+      flex-direction: row;
     }
   }
 
@@ -128,8 +131,6 @@
   }
 
   &__asset-image {
-    max-width: 100%;
-    height: auto;
     border-radius: $border-radius;
   }
 

--- a/packages/themes/pennwell/styles/components/_item.scss
+++ b/packages/themes/pennwell/styles/components/_item.scss
@@ -110,7 +110,7 @@
     &:empty {
       display: none;
     }
-    @include media-breakpoint-up("md", $grid-breakpoints) {
+    @include media-breakpoint-up(md) {
       flex-direction: row;
     }
   }


### PR DESCRIPTION
Removed previous settings from https://github.com/endeavorb2b/websites/pull/216

Adjusted footer direction to column, then row once it hits md breakpoint

This resolves the issue from the original PR, plus https://3.basecamp.com/4053736/buckets/11134315/todos/1888994912 and https://southcomm.atlassian.net/projects/CS/queues/custom/11/CS-2474, but still leaves the issue of company images displaying outside of their container below iPhone 6/7 Plus size of 414px…

See old images on Mimi's ToDo, linked above for basecamp.

New:

Overflowing on smaller phones (same for videos section above):
http://0.0.0.0:12171/global-thought-leaders?203583

![Screen Shot 2019-06-27 at 5 31 50 PM](https://user-images.githubusercontent.com/6343242/60305221-82ccfd00-9901-11e9-9b2d-bea7b79de627.png)

Fine on larger phones:
![Screen Shot 2019-06-27 at 5 32 03 PM](https://user-images.githubusercontent.com/6343242/60305245-97a99080-9901-11e9-95e1-f5c684192c5c.png)

