### PR TITLE
WW-globalThoughtMediaItems: updated video code

### DIFF
--- a/packages/themes/pennwell/styles/components/_item.scss
+++ b/packages/themes/pennwell/styles/components/_item.scss
@@ -322,4 +322,10 @@
     }
   }
 
+  // Video
+  &__video {
+    iframe {
+      max-width: 100%;
+    }
+  }
 }

--- a/sites/waterworld/server/templates/website-section/global-thought-leaders.marko
+++ b/sites/waterworld/server/templates/website-section/global-thought-leaders.marko
@@ -64,8 +64,7 @@ $ const aliases = hierarchyAliases(section);
                     />
                     <@header-left>Watch ${get(content, "company.name")}'s Video</@header-left>
                     <@description tag="div">
-                      <!-- @todo Bring in primary-video styling for item? -->
-                      <div class="content-page-body__primary-video">
+                      <div class="item__video">
                         $!{content.embedCode}
                       </div>
                     </@description>


### PR DESCRIPTION
Video iframe was overflowing it’s container on smaller phones, like iphone 5/6. Adjusted class based on discussion with Jacob and added styling to prevent overflow

https://www.waterworld.com/global-thought-leaders