### PR TITLE
Only display primary image if one exists

### DIFF
--- a/packages/common/components/content/blocks/primary-media.marko
+++ b/packages/common/components/content/blocks/primary-media.marko
@@ -5,7 +5,7 @@ $ const block = 'content-primary-media';
 $ const content = getAsObject(input, 'content');
 $ const primaryImage = getAsObject(content, 'primaryImage');
 
-$ const displayMedia = input.displayPrimaryImage || content.embedCode;
+$ const displayMedia = input.displayPrimaryImage && primaryImage.src || content.embedCode;
 
 <if(displayMedia)>
   <div class=block>


### PR DESCRIPTION
Partial revert of #267 -- previously the primaryImage was only being displayed if it was configured and if the content document had a primary image. This was inadvertently removed in that PR, causing content without a primary image to display empty primary image containers.

Ref [JIRA CS-2580](https://southcomm.atlassian.net/browse/CS-2580)

Current
<img width="1208" alt="Screen Shot 2019-07-10 at 3 44 02 PM" src="https://user-images.githubusercontent.com/1778222/61003434-9036ae00-a329-11e9-9ff6-0e7f52585c72.png">

New
<img width="1208" alt="Screen Shot 2019-07-10 at 3 43 51 PM" src="https://user-images.githubusercontent.com/1778222/61003440-9593f880-a329-11e9-8b2c-bb7a401771f2.png">
