### PR TITLE
Inline images on Media Galleries

### DIFF
--- a/packages/common/components/content/blocks/image-list.marko
+++ b/packages/common/components/content/blocks/image-list.marko
@@ -1,0 +1,25 @@
+import { getAsArray } from '@base-cms/object-path';
+
+$ const block = 'content-image-list';
+$ const images = getAsArray(input, 'imageConnection.edges').map(({ node }) => node);
+
+<if(images.length)>
+  <div class=block>
+    <for|image, index| of=images>
+      <div class=`${block}__item`>
+        <cms-text-element tag="div" class="title" field="displayName" obj=image />
+        <div class=`${block}__image`>
+          <!-- @todo Add support for responsive images / size variance based on context -->
+          <cms-image-element
+            block=block
+            lazyload=false
+            obj=image
+            options={ w: 720, h: 405, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
+          />
+        </div>
+        <cms-text-element tag="div" class="caption" field="caption" obj=image asHTML=true />
+        <cms-text-element tag="div" class="credit" field="credit" obj=image />
+      </div>
+    </for>
+  </div>
+</if>

--- a/packages/common/components/content/blocks/marko.json
+++ b/packages/common/components/content/blocks/marko.json
@@ -68,6 +68,10 @@
         "default-value": false
       }
     },
+    "endeavor-content-block-image-list": {
+      "template": "./image-list.marko",
+      "@image-connection": "object"
+    },
     "endeavor-content-block-item": {
       "template": "./item.marko",
       "@content": "object",

--- a/packages/common/components/content/blocks/page-body-contents.marko
+++ b/packages/common/components/content/blocks/page-body-contents.marko
@@ -14,4 +14,7 @@ $ const content = getAsObject(input, 'content');
   <if(content.type === "webinar")>
     <endeavor-content-block-webinar-button content=content />
   </if>
+  <if(content.type === "media-gallery")>
+    <endeavor-content-block-image-list image-connection=content.images />
+  </if>
 </div>

--- a/packages/common/components/content/blocks/primary-media.marko
+++ b/packages/common/components/content/blocks/primary-media.marko
@@ -25,12 +25,8 @@ $ const displayMedia = input.displayPrimaryImage && primaryImage.src && content.
           options={ w: 720, h: 405, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
         />
       </div>
-      <if(primaryImage.caption)>
-        <span class="caption">${primaryImage.caption}</span>
-      </if>
-      <if(primaryImage.credit)>
-        <span class="credit">${primaryImage.credit}</span>
-      </if>
+        <cms-text-element tag="div" class="caption" field="caption" obj=primaryImage asHTML=true />
+        <cms-text-element tag="div" class="credit" field="credit" obj=primaryImage />
     </else-if>
   </div>
 </if>

--- a/packages/common/components/content/blocks/primary-media.marko
+++ b/packages/common/components/content/blocks/primary-media.marko
@@ -5,7 +5,7 @@ $ const block = 'content-primary-media';
 $ const content = getAsObject(input, 'content');
 $ const primaryImage = getAsObject(content, 'primaryImage');
 
-$ const displayMedia = input.displayPrimaryImage && primaryImage.src && content.type !== 'media-gallery' || content.embedCode;
+$ const displayMedia = (input.displayPrimaryImage && primaryImage.src) || content.embedCode;
 
 <if(displayMedia)>
   <div class=block>

--- a/packages/common/components/content/blocks/primary-media.marko
+++ b/packages/common/components/content/blocks/primary-media.marko
@@ -5,7 +5,7 @@ $ const block = 'content-primary-media';
 $ const content = getAsObject(input, 'content');
 $ const primaryImage = getAsObject(content, 'primaryImage');
 
-$ const displayMedia = input.displayPrimaryImage && primaryImage.src || content.embedCode;
+$ const displayMedia = input.displayPrimaryImage && primaryImage.src && content.type !== 'media-gallery' || content.embedCode;
 
 <if(displayMedia)>
   <div class=block>

--- a/packages/themes/pennwell/api/fragments/content-page.js
+++ b/packages/themes/pennwell/api/fragments/content-page.js
@@ -124,5 +124,19 @@ fragment ContentPageFragment on Content {
       }
     }
   }
+  ... on ContentMediaGallery {
+    images {
+      edges {
+        node {
+          id
+          src
+          alt
+          displayName
+          caption
+          credit
+        }
+      }
+    }
+  }
 }
 `;

--- a/packages/themes/pennwell/styles/bootstrap/_mixins.scss
+++ b/packages/themes/pennwell/styles/bootstrap/_mixins.scss
@@ -254,6 +254,12 @@
   }
 }
 
+@mixin theme-media-title() {
+  @include theme-media-common-footer();
+  font-weight: 800;
+  color: $black;
+}
+
 @mixin theme-media-caption() {
   @include theme-media-common-footer();
   font-weight: 600;

--- a/packages/themes/pennwell/styles/components/_content.scss
+++ b/packages/themes/pennwell/styles/components/_content.scss
@@ -1,5 +1,6 @@
 @import "content/attribution";
 @import "content/contact-details";
+@import "content/image-list";
 @import "content/page";
 @import "content/primary-media";
 @import "content/query-hero";

--- a/packages/themes/pennwell/styles/components/content/_image-list.scss
+++ b/packages/themes/pennwell/styles/components/content/_image-list.scss
@@ -21,11 +21,11 @@
 
   &__image {
     @include theme-embed-responsive(16, 9);
-    border-radius: $border-radius;
-    box-shadow: $theme-box-shadow-lg;
+    @include border-radius($border-radius);
+    @include box-shadow($theme-box-shadow-lg);
     img {
       @include theme-embed-responsive-item();
-      border-radius: $border-radius;
+      @include border-radius($border-radius);
     }
   }
 }

--- a/packages/themes/pennwell/styles/components/content/_image-list.scss
+++ b/packages/themes/pennwell/styles/components/content/_image-list.scss
@@ -1,0 +1,31 @@
+.content-image-list {
+  margin-bottom: map-get($spacers, block);
+  .title {
+    @include theme-media-title();
+  }
+  .caption {
+    @include theme-media-caption();
+  }
+  .credit {
+    @include theme-media-credit();
+  }
+
+  &__item {
+    padding-bottom: $theme-item-padding;
+    margin-bottom: $theme-item-padding;
+    border-bottom: $list-group-border-width solid $list-group-border-color;
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  &__image {
+    @include theme-embed-responsive(16, 9);
+    border-radius: $border-radius;
+    box-shadow: $theme-box-shadow-lg;
+    img {
+      @include theme-embed-responsive-item();
+      border-radius: $border-radius;
+    }
+  }
+}

--- a/sites/aquamagazine/server/templates/content/index.marko
+++ b/sites/aquamagazine/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/athleticbusiness/server/templates/content/index.marko
+++ b/sites/athleticbusiness/server/templates/content/index.marko
@@ -11,7 +11,7 @@ $ const adSlots = {
   'gpt-ad-lb1': getAdUnit(site, { name: 'lb1', aliases }),
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/automationworld/server/templates/content/index.marko
+++ b/sites/automationworld/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/bioopticsworld/server/templates/content/index.marko
+++ b/sites/bioopticsworld/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/bizbash/server/templates/content/index.marko
+++ b/sites/bizbash/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/broadbandtechreport/server/templates/content/index.marko
+++ b/sites/broadbandtechreport/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/cablinginstall/server/templates/content/index.marko
+++ b/sites/cablinginstall/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/clevescene/server/templates/content/index.marko
+++ b/sites/clevescene/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/dentaleconomics/server/templates/content/index.marko
+++ b/sites/dentaleconomics/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases, size: [300, 250] }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases, size: [300, 250] }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/dentistryiq/server/templates/content/index.marko
+++ b/sites/dentistryiq/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases, size: [300, 250] }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases, size: [300, 250] }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/evaluationengineering/server/templates/content/index.marko
+++ b/sites/evaluationengineering/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-right1': getAdUnit(site, { name: 'MR', aliases }),
   'gpt-ad-right2': getAdUnit(site, { name: 'MR', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/forconstructionpros/server/templates/content/index.marko
+++ b/sites/forconstructionpros/server/templates/content/index.marko
@@ -11,7 +11,7 @@ $ const adSlots = {
   'gpt-ad-lb1': getAdUnit(site, { name: 'lb1', aliases }),
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/healthcarepackaging/server/templates/content/index.marko
+++ b/sites/healthcarepackaging/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/industrial-lasers/server/templates/content/index.marko
+++ b/sites/industrial-lasers/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases, size: [300, 250] }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases, size: [300, 600] }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/intelligent-aerospace/server/templates/content/index.marko
+++ b/sites/intelligent-aerospace/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/laserfocusworld/server/templates/content/index.marko
+++ b/sites/laserfocusworld/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/ledsmagazine/server/templates/content/index.marko
+++ b/sites/ledsmagazine/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/lightwaveonline/server/templates/content/index.marko
+++ b/sites/lightwaveonline/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/metrotimes/server/templates/content/index.marko
+++ b/sites/metrotimes/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/militaryaerospace/server/templates/content/index.marko
+++ b/sites/militaryaerospace/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/mundopmmi/server/templates/content/index.marko
+++ b/sites/mundopmmi/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/oemmagazine/server/templates/content/index.marko
+++ b/sites/oemmagazine/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/officer/server/templates/content/index.marko
+++ b/sites/officer/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-right1': getAdUnit(site, { name: 'MR', aliases }),
   'gpt-ad-right2': getAdUnit(site, { name: 'MR', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/offshore-mag/server/templates/content/index.marko
+++ b/sites/offshore-mag/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/ogj/server/templates/content/index.marko
+++ b/sites/ogj/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/orlandoweekly/server/templates/content/index.marko
+++ b/sites/orlandoweekly/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/outinsa/server/templates/content/index.marko
+++ b/sites/outinsa/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/outinstl/server/templates/content/index.marko
+++ b/sites/outinstl/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/packworld/server/templates/content/index.marko
+++ b/sites/packworld/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/perioimplantadvisory/server/templates/content/index.marko
+++ b/sites/perioimplantadvisory/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases, size: [300, 250] }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases, size: [300, 250] }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/plasticsmachinerymagazine/server/templates/content/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-right1': getAdUnit(site, { name: 'MR', aliases }),
   'gpt-ad-right2': getAdUnit(site, { name: 'MR', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/profoodworld/server/templates/content/index.marko
+++ b/sites/profoodworld/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/rdhmag/server/templates/content/index.marko
+++ b/sites/rdhmag/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases, size: [300, 250] }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases, size: [300, 250] }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/riverfronttimes/server/templates/content/index.marko
+++ b/sites/riverfronttimes/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/sacurrent/server/templates/content/index.marko
+++ b/sites/sacurrent/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/strategies-u/server/templates/content/index.marko
+++ b/sites/strategies-u/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/utilityproducts/server/templates/content/index.marko
+++ b/sites/utilityproducts/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/vision-systems/server/templates/content/index.marko
+++ b/sites/vision-systems/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/waterworld/server/templates/content/index.marko
+++ b/sites/waterworld/server/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>

--- a/sites/woodfloorbusiness/server/templates/content/index.marko
+++ b/sites/woodfloorbusiness/server/templates/content/index.marko
@@ -13,7 +13,7 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
-$ const displayPrimaryImage = (content.type === 'whitepaper') ? false : true;
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 
 <theme-pennwell-content-layout content=content>
   <@head>


### PR DESCRIPTION
Requires base-cms/base-cms#119

- Displays all media gallery related images after the content body.
- Disables primary image display for media galleries
- Adds support for the `displayName` image field
- Adds support for rendering image captions as HTML

## Bizbash
[BZB Icarus media gallery](https://www.bizbash.com/corporate/media-gallery/21077290/new-york-event-venues-for-summer-2019)
![bzb](https://user-images.githubusercontent.com/1778222/61073392-ef083000-a3da-11e9-9fe1-fc2a1fe01d8f.jpg)

## Officer
[OFCR Icarus media gallery](https://www.officer.com/on-the-street/media-gallery/21039199/the-top-products-of-lepn-2018)
![ofcr](https://user-images.githubusercontent.com/1778222/61073402-f7f90180-a3da-11e9-910a-c9a2f2adb535.jpg)
