### PR TITLE
Bizbash Venue support

### DIFF
--- a/sites/bizbash/components/marko.json
+++ b/sites/bizbash/components/marko.json
@@ -22,6 +22,10 @@
     },
     "bizbash-inquiry-form": {
       "template": "./inquiry-form.marko"
+    },
+    "bizbash-venue-capacity": {
+      "template": "./venue-capacity.marko",
+      "@spaces": "array"
     }
   }
 }

--- a/sites/bizbash/components/venue-capacity.marko
+++ b/sites/bizbash/components/venue-capacity.marko
@@ -24,7 +24,7 @@ $ const spaces = getAsArray(input, 'spaces');
             <td>${space.area}</td>
             <td>
               <if(space.floorPlan)>
-                <a href=space.floorPlan.src target="_blank" alt=space.floorPlan.alt>View</a>
+                <endeavor-link href=space.floorPlan.src target="_blank" alt=space.floorPlan.alt>View</endeavor-link>
               </if>
             </td>
           </tr>

--- a/sites/bizbash/components/venue-capacity.marko
+++ b/sites/bizbash/components/venue-capacity.marko
@@ -1,0 +1,35 @@
+import { getAsArray } from '@base-cms/object-path';
+
+$ const spaces = getAsArray(input, 'spaces');
+
+<if(spaces.length)>
+  <h4>Venue Capacity</h4>
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th scope="col">Space</th>
+          <th scope="col">Max. Reception Capacity</th>
+          <th scope="col">Max. Seated Capacity</th>
+          <th scope="col">Sq. Feet</th>
+          <th scope="col">Floor Plan</th>
+        </tr>
+      </thead>
+      <tbody>
+        <for|space| of=spaces>
+          <tr>
+            <td>${space.name}</td>
+            <td>${space.capacityMaxStanding}</td>
+            <td>${space.capacityMaxSeated}</td>
+            <td>${space.area}</td>
+            <td>
+              <if(space.floorPlan)>
+                <a href=space.floorPlan.src target="_blank" alt=space.floorPlan.alt>View</a>
+              </if>
+            </td>
+          </tr>
+        </for>
+      </tbody>
+    </table>
+  </div>
+</if>

--- a/sites/bizbash/server/api/fragments/content-page.js
+++ b/sites/bizbash/server/api/fragments/content-page.js
@@ -39,6 +39,36 @@ module.exports = gql`
         }
       }
     }
+    ... on ContentVenue {
+      images(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
+        edges {
+          node {
+            id
+            src
+            alt
+            displayName
+            credit
+            caption
+          }
+        }
+      }
+      spaces {
+        edges {
+          node {
+            id
+            name
+            area
+            capacityMin
+            capacityMaxSeated
+            capacityMaxStanding
+            floorPlan {
+              id
+              src
+            }
+          }
+        }
+      }
+    }
   }
   ${contentPageFragment}
 `;

--- a/sites/bizbash/server/routes/content.js
+++ b/sites/bizbash/server/routes/content.js
@@ -3,6 +3,7 @@ const queryFragment = require('../api/fragments/content-page');
 const content = require('../templates/content');
 const supplier = require('../templates/content/supplier');
 const topList = require('../templates/content/top-list');
+const venue = require('../templates/content/venue');
 
 module.exports = (app) => {
   app.get('/*?supplier/:id(\\d{8})*', withContent({
@@ -11,6 +12,10 @@ module.exports = (app) => {
   }));
   app.get('/*?top-list/:id(\\d{8})*', withContent({
     template: topList,
+    queryFragment,
+  }));
+  app.get('/*?venue/:id(\\d{8})*', withContent({
+    template: venue,
     queryFragment,
   }));
   app.get('/*?:id(\\d{8})*', withContent({

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -31,6 +31,7 @@ $theme-carousel-caption-background: rgba(0, 0, 0, .75);
 
 @import "../../node_modules/@endeavorb2b/base-website-themes/orion/styles/theme";
 @import "../../node_modules/bootstrap/scss/carousel";
+@import "../../node_modules/bootstrap/scss/tables";
 
 .carousel {
   .carousel-item {

--- a/sites/bizbash/server/templates/content/venue.marko
+++ b/sites/bizbash/server/templates/content/venue.marko
@@ -13,6 +13,8 @@ $ const adSlots = {
   'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
   'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
 };
+$ const images = getAsArray(content, 'images.edges').map(({ node }) => node);
+$ const spaces = getAsArray(content, 'spaces.edges').map(({ node }) => node);
 
 <theme-default-content-layout content=content>
   <@head>
@@ -24,12 +26,11 @@ $ const adSlots = {
     <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
 
-    $ const images = getAsArray(content, 'images.edges').map(({ node }) => node);
-    <bizbash-image-slider images=images />
   </@above-container>
 
   <div class="page-wrapper">
     <div class="page-wrapper__header">
+      <bizbash-image-slider images=images />
       <endeavor-content-block-page-header content=content />
     </div>
 
@@ -37,7 +38,6 @@ $ const adSlots = {
       <div class="col-lg-8">
         <endeavor-content-block-page-body content=content display-primary-image=false  />
         <div class="page-wrapper__body">
-          $ const spaces = getAsArray(content, 'spaces.edges').map(({ node }) => node);
           <bizbash-venue-capacity spaces=spaces />
         </div>
       </div>

--- a/sites/bizbash/server/templates/content/venue.marko
+++ b/sites/bizbash/server/templates/content/venue.marko
@@ -25,7 +25,6 @@ $ const spaces = getAsArray(content, 'spaces.edges').map(({ node }) => node);
     <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
     <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
-
   </@above-container>
 
   <div class="page-wrapper">

--- a/sites/bizbash/server/templates/content/venue.marko
+++ b/sites/bizbash/server/templates/content/venue.marko
@@ -1,0 +1,62 @@
+import { getAsObject, getAsArray, get } from '@base-cms/object-path';
+import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import hierarchyAliases from '@endeavorb2b/base-website-common/utils/website-section/hierarchy-aliases';
+
+$ const { site } = out.global;
+$ const content = getAsObject(data, 'content');
+$ const section = getAsObject(content, 'primarySection');
+$ const aliases = hierarchyAliases(section);
+$ const block = 'content-page';
+$ const adSlots = {
+  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1', aliases }),
+  'gpt-ad-lb2': getAdUnit(site, { name: 'lb2', aliases }),
+  'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
+  'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
+};
+
+<theme-default-content-layout content=content>
+  <@head>
+    <endeavor-ad-gam-head slots=adSlots targeting={ cont_id: content.id, cont_type: content.type } />
+  </@head>
+
+  <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
+    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+
+    $ const images = getAsArray(content, 'images.edges').map(({ node }) => node);
+    <bizbash-image-slider images=images />
+  </@above-container>
+
+  <div class="page-wrapper">
+    <div class="page-wrapper__header">
+      <endeavor-content-block-page-header content=content />
+    </div>
+
+    <div class="row">
+      <div class="col-lg-8">
+        <endeavor-content-block-page-body content=content display-primary-image=false  />
+        <div class="page-wrapper__body">
+          $ const spaces = getAsArray(content, 'spaces.edges').map(({ node }) => node);
+          <bizbash-venue-capacity spaces=spaces />
+        </div>
+      </div>
+
+      <aside class="col-lg-4">
+        <bizbash-inquiry-form content=content />
+      </aside>
+    </div>
+  </div>
+
+  <@below-container>
+    <endeavor-content-query-load-more-related
+      header=`More from ${content.name}`
+      query={ contentId: content.id }
+      ads={ aliases }
+    />
+  </@below-container>
+
+  <@footer>
+    <endeavor-gam-ad-sticky-leaderboard name="lb2" refreshable=true aliases=aliases />
+  </@footer>
+</theme-default-content-layout>


### PR DESCRIPTION
Requires:
- [x] #299 
  - [x] Rebase
- [x] base-cms/base-cms#122
  - [x] Update graphql-fragment-types package

Adds support for the Venue content type for Bizbash, including the custom Image Slider header and Venue Spaces table below content body. Scrolls into related content, same as suppliers.

![screencapture-0-0-0-0-12190-venue-directory-bars-nightclubs-lounges-bars-lounges-venue-13385718-terminal-5-2019-07-17-10_51_04](https://user-images.githubusercontent.com/1778222/61390723-edc67f80-a880-11e9-960d-5d58d3c57c19.jpg)
