### PR TITLE
Bizbash TopList support

### DIFF
--- a/packages/themes/default/api/fragments/content-page.js
+++ b/packages/themes/default/api/fragments/content-page.js
@@ -125,7 +125,7 @@ fragment ContentPageFragment on Content {
     }
   }
   ... on ContentMediaGallery {
-    images {
+    images(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
       edges {
         node {
           id

--- a/sites/bizbash/components/image-format.js
+++ b/sites/bizbash/components/image-format.js
@@ -1,0 +1,15 @@
+const { buildImgixUrl } = require('@base-cms/image');
+
+const defaults = {
+  fit: 'crop',
+  crop: 'focalpoint',
+  fpX: 0.5,
+  fpY: 0.5,
+  w: 680,
+  h: 380,
+};
+
+module.exports = (image, options = {}) => {
+  const src = buildImgixUrl(image.src, { ...defaults, ...options });
+  return { ...image, src };
+};

--- a/sites/bizbash/components/image-format.js
+++ b/sites/bizbash/components/image-format.js
@@ -1,15 +1,6 @@
 const { buildImgixUrl } = require('@base-cms/image');
 
-const defaults = {
-  fit: 'crop',
-  crop: 'focalpoint',
-  fpX: 0.5,
-  fpY: 0.5,
-  w: 680,
-  h: 380,
-};
-
 module.exports = (image, options = {}) => {
-  const src = buildImgixUrl(image.src, { ...defaults, ...options });
+  const src = buildImgixUrl(image.src, options);
   return { ...image, src };
 };

--- a/sites/bizbash/components/image-list.marko
+++ b/sites/bizbash/components/image-list.marko
@@ -1,0 +1,33 @@
+import { buildImgixUrl } from '@base-cms/image';
+import { getAsArray } from '@base-cms/object-path';
+
+$ const block = 'top-list';
+$ const connection = getAsArray(input, 'images.edges');
+$ const imageOptions = {
+  fit: 'crop',
+  crop: 'focalpoint',
+  fpX: 0.5,
+  fpY: 0.5,
+  w: 680,
+  h: 380,
+};
+$ const imageFormat = (image) => {
+  const src = buildImgixUrl(image.src, imageOptions);
+  return { ...image, src };
+};
+
+<if(connection.length)>
+  $ const images = connection.map(({ node }) => imageFormat(node));
+  <div class=`${block}__row`>
+    <for|image| of=images>
+      <div class=`${block}__column`>
+        <a class=`${block}__link` href=input.link title="View Image Gallery">
+          <img class="img-fluid" src=image.src alt=image.alt />
+          <div class=`${block}__overlay`>
+            <small>${image.displayName}</small>
+          </div>
+        </a>
+      </div>
+    </for>
+  </div>
+</if>

--- a/sites/bizbash/components/image-list.marko
+++ b/sites/bizbash/components/image-list.marko
@@ -7,12 +7,12 @@ $ const images = getAsArray(input, 'images');
   <div class=`${block}__row`>
     <for|image| of=images>
       <div class=`${block}__col`>
-        <a class=`${block}__link` href=input.link title="View Image Gallery">
-          <img class="img-fluid" src=image.src alt=image.alt />
+        <endeavor-link class=`${block}__link` href=input.link title="View Image Gallery">
+          <img src=image.src alt=image.alt />
           <div class=`${block}__overlay`>
             <small class=`${block}__small`>${image.displayName}</small>
           </div>
-        </a>
+        </endeavor-link>
       </div>
     </for>
   </div>

--- a/sites/bizbash/components/image-list.marko
+++ b/sites/bizbash/components/image-list.marko
@@ -1,6 +1,6 @@
 import { getAsArray } from '@base-cms/object-path';
 
-$ const block = 'top-list';
+$ const { block } = input;
 $ const images = getAsArray(input, 'images');
 
 <if(images.length)>

--- a/sites/bizbash/components/image-list.marko
+++ b/sites/bizbash/components/image-list.marko
@@ -1,30 +1,16 @@
-import { buildImgixUrl } from '@base-cms/image';
 import { getAsArray } from '@base-cms/object-path';
 
 $ const block = 'top-list';
-$ const connection = getAsArray(input, 'images.edges');
-$ const imageOptions = {
-  fit: 'crop',
-  crop: 'focalpoint',
-  fpX: 0.5,
-  fpY: 0.5,
-  w: 680,
-  h: 380,
-};
-$ const imageFormat = (image) => {
-  const src = buildImgixUrl(image.src, imageOptions);
-  return { ...image, src };
-};
+$ const images = getAsArray(input, 'images');
 
-<if(connection.length)>
-  $ const images = connection.map(({ node }) => imageFormat(node));
+<if(images.length)>
   <div class=`${block}__row`>
     <for|image| of=images>
-      <div class=`${block}__column`>
+      <div class=`${block}__col`>
         <a class=`${block}__link` href=input.link title="View Image Gallery">
           <img class="img-fluid" src=image.src alt=image.alt />
           <div class=`${block}__overlay`>
-            <small>${image.displayName}</small>
+            <small class=`${block}__small`>${image.displayName}</small>
           </div>
         </a>
       </div>

--- a/sites/bizbash/components/image-list.marko
+++ b/sites/bizbash/components/image-list.marko
@@ -10,7 +10,7 @@ $ const images = getAsArray(input, 'images');
         <endeavor-link class=`${block}__link` href=input.link title="View Image Gallery">
           <img src=image.src alt=image.alt />
           <div class=`${block}__overlay`>
-            <small class=`${block}__small`>${image.displayName}</small>
+            <small class=`${block}__name`>${image.displayName}</small>
           </div>
         </endeavor-link>
       </div>

--- a/sites/bizbash/components/image-slider.marko
+++ b/sites/bizbash/components/image-slider.marko
@@ -1,7 +1,15 @@
 import { getAsArray } from '@base-cms/object-path';
 import imageFormat from './image-format';
 
-$ const images = getAsArray(input, 'images').map(node => imageFormat(node, { w: 1200, h: 515 }));
+$ const imageOptions = {
+  fit: 'crop',
+  crop: 'focalpoint',
+  fpX: 0.5,
+  fpY: 0.5,
+  w: 1200,
+  h: 515,
+};
+$ const images = getAsArray(input, 'images').map(node => imageFormat(node, imageOptions));
 
 <if(images.length)>
   <div class="row">

--- a/sites/bizbash/components/image-slider.marko
+++ b/sites/bizbash/components/image-slider.marko
@@ -1,19 +1,7 @@
-import { buildImgixUrl } from '@base-cms/image';
 import { getAsArray } from '@base-cms/object-path';
+import imageFormat from './image-format';
 
-$ const imageOptions = {
-  fit: 'crop',
-  crop: 'focalpoint',
-  fpX: 0.5,
-  fpY: 0.5,
-  h: 515,
-  w: 1200,
-};
-$ const imageFormat = (image) => {
-  const src = buildImgixUrl(image.src, imageOptions);
-  return { ...image, src };
-};
-$ const images = getAsArray(input, 'images').map(node => imageFormat(node));
+$ const images = getAsArray(input, 'images').map(node => imageFormat(node, { w: 1200, h: 515 }));
 
 <if(images.length)>
   <div class="row">

--- a/sites/bizbash/components/marko.json
+++ b/sites/bizbash/components/marko.json
@@ -4,10 +4,21 @@
       "template": "./image-slider.marko"
     },
     "bizbash-top-list-galleries": {
-      "template": "./top-list-galleries.marko"
+      "template": "./top-list-galleries.marko",
+      "@block": {
+        "type": "string",
+        "default-value": "top-list"
+      },
+      "@galleries": "array"
     },
     "bizbash-image-list": {
-      "template": "./image-list.marko"
+      "template": "./image-list.marko",
+      "@block": {
+        "type": "string",
+        "default-value": "top-list"
+      },
+      "@images": "array",
+      "@link": "string"
     },
     "bizbash-inquiry-form": {
       "template": "./inquiry-form.marko"

--- a/sites/bizbash/components/marko.json
+++ b/sites/bizbash/components/marko.json
@@ -3,6 +3,12 @@
     "bizbash-image-slider": {
       "template": "./image-slider.marko"
     },
+    "bizbash-top-list-galleries": {
+      "template": "./top-list-galleries.marko"
+    },
+    "bizbash-image-list": {
+      "template": "./image-list.marko"
+    },
     "bizbash-inquiry-form": {
       "template": "./inquiry-form.marko"
     }

--- a/sites/bizbash/components/top-list-galleries.marko
+++ b/sites/bizbash/components/top-list-galleries.marko
@@ -1,0 +1,12 @@
+import { buildImgixUrl } from '@base-cms/image';
+import { getAsArray } from '@base-cms/object-path';
+
+$ const connection = getAsArray(input, 'galleries.edges');
+
+<if(connection.length)>
+  $ const galleries = connection.map(({ node }) => node);
+  <for|gallery| of=galleries>
+    <h4 class="top-list__title">${gallery.shortName}</h4>
+    <bizbash-image-list link=gallery.canonicalPath images=gallery.images />
+  </for>
+</if>

--- a/sites/bizbash/components/top-list-galleries.marko
+++ b/sites/bizbash/components/top-list-galleries.marko
@@ -3,11 +3,19 @@ import imageFormat from './image-format';
 
 $ const galleries = getAsArray(input, 'galleries');
 $ const { block } = input;
+$ const imageOptions = {
+  fit: 'crop',
+  crop: 'focalpoint',
+  fpX: 0.5,
+  fpY: 0.5,
+  w: 680,
+  h: 380,
+};
 
 <if(galleries.length)>
   <for|gallery| of=galleries>
     <h4 class=`${block}__title`>${gallery.shortName}</h4>
-    $ const images = getAsArray(gallery, 'images.edges').map(({ node }) => imageFormat(node, { w: 680, h: 380 }));
+    $ const images = getAsArray(gallery, 'images.edges').map(({ node }) => imageFormat(node, imageOptions));
     <bizbash-image-list link=gallery.canonicalPath images=images block=block />
   </for>
 </if>

--- a/sites/bizbash/components/top-list-galleries.marko
+++ b/sites/bizbash/components/top-list-galleries.marko
@@ -2,11 +2,12 @@ import { getAsArray } from '@base-cms/object-path';
 import imageFormat from './image-format';
 
 $ const galleries = getAsArray(input, 'galleries');
+$ const { block } = input;
 
 <if(galleries.length)>
   <for|gallery| of=galleries>
-    <h4 class="top-list__title">${gallery.shortName}</h4>
+    <h4 class=`${block}__title`>${gallery.shortName}</h4>
     $ const images = getAsArray(gallery, 'images.edges').map(({ node }) => imageFormat(node, { w: 680, h: 380 }));
-    <bizbash-image-list link=gallery.canonicalPath images=images />
+    <bizbash-image-list link=gallery.canonicalPath images=images block=block />
   </for>
 </if>

--- a/sites/bizbash/components/top-list-galleries.marko
+++ b/sites/bizbash/components/top-list-galleries.marko
@@ -1,12 +1,12 @@
-import { buildImgixUrl } from '@base-cms/image';
 import { getAsArray } from '@base-cms/object-path';
+import imageFormat from './image-format';
 
-$ const connection = getAsArray(input, 'galleries.edges');
+$ const galleries = getAsArray(input, 'galleries');
 
-<if(connection.length)>
-  $ const galleries = connection.map(({ node }) => node);
+<if(galleries.length)>
   <for|gallery| of=galleries>
     <h4 class="top-list__title">${gallery.shortName}</h4>
-    <bizbash-image-list link=gallery.canonicalPath images=gallery.images />
+    $ const images = getAsArray(gallery, 'images.edges').map(({ node }) => imageFormat(node, { w: 680, h: 380 }));
+    <bizbash-image-list link=gallery.canonicalPath images=images />
   </for>
 </if>

--- a/sites/bizbash/package.json
+++ b/sites/bizbash/package.json
@@ -11,6 +11,7 @@
     "test": "yarn lint && yarn build"
   },
   "dependencies": {
+    "@base-cms/image": "^0.9.22",
     "@base-cms/marko-web": "^0.9.40",
     "@base-cms/object-path": "^0.9.40",
     "@base-cms/web-cli": "^0.9.40",

--- a/sites/bizbash/server/api/fragments/content-page.js
+++ b/sites/bizbash/server/api/fragments/content-page.js
@@ -11,7 +11,7 @@ module.exports = gql`
             id
             shortName
             canonicalPath
-            images {
+            images(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
               edges {
                 node {
                   id
@@ -26,7 +26,7 @@ module.exports = gql`
       }
     }
     ... on ContentSupplier {
-      images {
+      images(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
         edges {
           node {
             id

--- a/sites/bizbash/server/api/fragments/content-page.js
+++ b/sites/bizbash/server/api/fragments/content-page.js
@@ -5,7 +5,7 @@ module.exports = gql`
   fragment BzbContentPageFragment on Content {
     ...ContentPageFragment
     ... on ContentTopList {
-      relatedTo(input:{sort:{order:values}}) {
+      relatedTo(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
         edges {
           node {
             id

--- a/sites/bizbash/server/api/fragments/content-page.js
+++ b/sites/bizbash/server/api/fragments/content-page.js
@@ -4,6 +4,27 @@ const contentPageFragment = require('@endeavorb2b/base-website-themes/default/ap
 module.exports = gql`
   fragment BzbContentPageFragment on Content {
     ...ContentPageFragment
+    ... on ContentTopList {
+      relatedTo(input:{sort:{order:values}}) {
+        edges {
+          node {
+            id
+            shortName
+            canonicalPath
+            images {
+              edges {
+                node {
+                  id
+                  src
+                  alt
+                  displayName
+                }
+              }
+            }
+          }
+        }
+      }
+    }
     ... on ContentSupplier {
       images {
         edges {

--- a/sites/bizbash/server/routes/content.js
+++ b/sites/bizbash/server/routes/content.js
@@ -2,10 +2,15 @@ const { withContent } = require('@base-cms/marko-web/middleware');
 const queryFragment = require('../api/fragments/content-page');
 const content = require('../templates/content');
 const supplier = require('../templates/content/supplier');
+const topList = require('../templates/content/top-list');
 
 module.exports = (app) => {
   app.get('/*?supplier/:id(\\d{8})*', withContent({
     template: supplier,
+    queryFragment,
+  }));
+  app.get('/*?top-list/:id(\\d{8})*', withContent({
+    template: topList,
     queryFragment,
   }));
   app.get('/*?:id(\\d{8})*', withContent({

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -85,6 +85,10 @@ $theme-carousel-caption-background: rgba(0, 0, 0, .75);
   }
   &__link {
     display: block;
+    img {
+      max-width: 100%;
+      height: auto;
+    }
   }
   &__overlay {
     &:empty {

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -76,7 +76,7 @@ $theme-carousel-caption-background: rgba(0, 0, 0, .75);
     flex-wrap: wrap;
     margin-bottom: map-get($spacers, block);
   }
-  &__column {
+  &__col {
     margin-bottom: map-get($spacers, block);
     @include make-col-ready();
     @include media-breakpoint-up(md) {
@@ -87,9 +87,8 @@ $theme-carousel-caption-background: rgba(0, 0, 0, .75);
     display: block;
   }
   &__overlay {
-    small {
-      margin: 0 auto;
-      color: $white;
+    &:empty {
+      display: none;
     }
     position: absolute;
     top: 0;
@@ -102,7 +101,8 @@ $theme-carousel-caption-background: rgba(0, 0, 0, .75);
     text-align: center;
     background: rgba(0, 0, 0, .5);
   }
-  &__overlay:empty {
-    display: none;
+  &__small {
+    margin: 0 auto;
+    color: $white;
   }
 }

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -105,7 +105,7 @@ $theme-carousel-caption-background: rgba(0, 0, 0, .75);
     text-align: center;
     background: rgba(0, 0, 0, .5);
   }
-  &__small {
+  &__name {
     margin: 0 auto;
     color: $white;
   }

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -67,8 +67,19 @@ $theme-carousel-caption-background: rgba(0, 0, 0, .75);
 
 .top-list {
   &__title {
-    @include theme-page-body-spacing();
-    @include theme-content-heading(h4);
+    padding-right: $theme-page-body-padding;
+    padding-left: $theme-page-body-padding;
+    margin-bottom: $theme-page-body-margin-bottom;
+    @include media-breakpoint-down($theme-responsive-text-breakpoint) {
+      padding-right: $theme-page-body-padding-sm;
+      padding-left: $theme-page-body-padding-sm;
+      margin-bottom: $theme-page-body-margin-bottom-sm;
+    }
+    @include theme-heading(h4);
+    margin-bottom: $theme-content-heading-h4-margin-bottom;
+    @include media-breakpoint-down($theme-responsive-text-breakpoint) {
+      margin-bottom: $theme-content-heading-h4-margin-bottom-sm;
+    }
   }
   &__row {
     display: flex;

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -64,3 +64,45 @@ $theme-carousel-caption-background: rgba(0, 0, 0, .75);
     content: "*";
   }
 }
+
+.top-list {
+  &__title {
+    @include theme-page-body-spacing();
+    @include theme-content-heading(h4);
+  }
+  &__row {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    margin-bottom: map-get($spacers, block);
+  }
+  &__column {
+    margin-bottom: map-get($spacers, block);
+    @include make-col-ready();
+    @include media-breakpoint-up(md) {
+      @include make-col(4);
+    }
+  }
+  &__link {
+    display: block;
+  }
+  &__overlay {
+    small {
+      margin: 0 auto;
+      color: $white;
+    }
+    position: absolute;
+    top: 0;
+    right: .9rem;
+    bottom: 0;
+    left: .9rem;
+    display: flex;
+    align-items: center;
+    padding: 1rem;
+    text-align: center;
+    background: rgba(0, 0, 0, .5);
+  }
+  &__overlay:empty {
+    display: none;
+  }
+}

--- a/sites/bizbash/server/templates/content/top-list.marko
+++ b/sites/bizbash/server/templates/content/top-list.marko
@@ -1,0 +1,75 @@
+import { getAsObject, get, getAsArray } from '@base-cms/object-path';
+import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import hierarchyAliases from '@endeavorb2b/base-website-common/utils/website-section/hierarchy-aliases';
+import { buildImgixUrl } from '@base-cms/image';
+
+$ const { site } = out.global;
+$ const content = getAsObject(data, 'content');
+$ const section = getAsObject(content, 'primarySection');
+$ const aliases = hierarchyAliases(section);
+$ const block = 'content-page';
+$ const adSlots = {
+  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1', aliases }),
+  'gpt-ad-lb2': getAdUnit(site, { name: 'lb2', aliases }),
+  'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases }),
+  'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases }),
+};
+$ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
+
+<theme-default-content-layout content=content>
+  <@head>
+    <endeavor-ad-gam-head slots=adSlots targeting={ cont_id: content.id, cont_type: content.type } />
+  </@head>
+
+  <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
+    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+  </@above-container>
+
+  <div class="page-wrapper">
+    <div class="row">
+      <div class="col">
+        <div class="page-wrapper__header">
+          <endeavor-content-block-page-header content=content />
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-lg-8">
+        <endeavor-content-block-page-body content=content display-primary-image=displayPrimaryImage />
+        <bizbash-top-list-galleries galleries=content.relatedTo />
+      </div>
+
+      <aside class="col-lg-4">
+        <endeavor-gam-ad-unit-display id="gpt-ad-rail1" modifiers=["content-page-right"] />
+        <endeavor-content-query-related
+          exclude-content-ids=[content.id]
+          section-id=section.id
+          native-x={ placement: 'list1', aliases, index: 4 }
+        />
+        <endeavor-gam-ad-unit-display id="gpt-ad-rail2" modifiers=["content-page-right"] />
+      </aside>
+    </div>
+  </div>
+
+  <@below-container>
+    <if(section.id)>
+      <endeavor-content-query-load-more
+        header=`More in ${section.name}`
+        query={
+          skip: 5,
+          excludeContentIds: [content.id],
+          sectionId: section.id,
+        }
+        ads={ aliases }
+        native-x={ placement: 'card', aliases, index: 0 }
+      />
+    </if>
+  </@below-container>
+
+  <@footer>
+    <endeavor-gam-ad-sticky-leaderboard name="lb2" refreshable=true aliases=aliases />
+  </@footer>
+</theme-default-content-layout>

--- a/sites/bizbash/server/templates/content/top-list.marko
+++ b/sites/bizbash/server/templates/content/top-list.marko
@@ -39,7 +39,8 @@ $ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.t
     <div class="row">
       <div class="col-lg-8">
         <endeavor-content-block-page-body content=content display-primary-image=displayPrimaryImage />
-        <bizbash-top-list-galleries galleries=content.relatedTo />
+        $ const galleries = getAsArray(content, 'relatedTo.edges').map(({ node }) => node);
+        <bizbash-top-list-galleries galleries=galleries />
       </div>
 
       <aside class="col-lg-4">


### PR DESCRIPTION
Requires:
- [x] #299
  - [x] Rebase 
- [x] base-cms/base-cms#122
  - [x] #305 or rebase
  - [x] Update graphql-fragment-types package
- [x] base-cms/base-cms#123
  - [x] Support for specifying `pagination.limit` on `Content.images` query needs to be added still.
  - [x] Change default sort for relatedTo to use `values`.

Adds support for the TopList content type for Bizbash, including the custom inline media gallery links below content body. Scrolls into standard section content.

![bzb-top-list-updated](https://user-images.githubusercontent.com/1778222/61327219-029e0700-a7de-11e9-9489-9e764ed6a2f6.jpg)
