### PR TITLE
Ensure fetch `credentials` default to same-origin

### DIFF
--- a/packages/identity-x/browser/create-client.js
+++ b/packages/identity-x/browser/create-client.js
@@ -15,6 +15,7 @@ export default ({ mountPoint = '/__idx' } = {}) => (path, body) => {
   const endpoint = path.replace(/^\/+/, '');
   const uri = `${mountPoint}/${endpoint}`;
   return fetch(uri, {
+    credentials: 'same-origin',
     method: 'post',
     headers: { 'content-type': 'application/json' },
     body: body ? JSON.stringify(body) : undefined,


### PR DESCRIPTION
[JIRA CS-2629](https://southcomm.atlassian.net/browse/CS-2629)

Ensures that cookies will be sent and set from XHRs in older browsers. Resolves issues with Edge ~15 login for OGJ