### PR TITLE
CS2187-Webinar: added webinar content type

### DIFF
--- a/packages/common/components/content/blocks/item.marko
+++ b/packages/common/components/content/blocks/item.marko
@@ -57,7 +57,7 @@ $ if (userRegistration.isRequired && identityX) titleModifiers.push('locked');
       </else>
     </@footer-left>
     <@footer-right|{ block }|>
-      <if(content.type === 'event')>
+      <if(content.type === 'event' || content.type === 'webinar')>
         <span class=`${block}__content-event-dates`>
           <endeavor-content-starts block=block obj=content />
           <endeavor-content-ends block=block obj=content />


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/CS-2187

Webcasts aren’t include in the events content type. Added the webinar content type to cover their list item date references.