### PR TITLE
BizBash website section layouts, ad unit updates

### DIFF
--- a/sites/bizbash/config/ads.js
+++ b/sites/bizbash/config/ads.js
@@ -38,6 +38,7 @@ module.exports = {
     rail1: { ...CONTENT, path: path('production-strategy/rail1') },
     rail2: { ...CONTENT, path: path('production-strategy/rail2') },
     'load-more': { ...CONTENT, path: path('production-strategy/load-more') },
+    reskin: { ...RESKIN, path: path('production-strategy/reskin') },
   },
   'style-decor': {
     lb1: { ...LB1, path: path('style-decor/lb1') },
@@ -45,6 +46,7 @@ module.exports = {
     rail1: { ...CONTENT, path: path('style-decor/rail1') },
     rail2: { ...CONTENT, path: path('style-decor/rail2') },
     'load-more': { ...CONTENT, path: path('style-decor/load-more') },
+    reskin: { ...RESKIN, path: path('style-decor/reskin') },
   },
   catering: {
     lb1: { ...LB1, path: path('catering/lb1') },
@@ -52,6 +54,7 @@ module.exports = {
     rail1: { ...CONTENT, path: path('catering/rail1') },
     rail2: { ...CONTENT, path: path('catering/rail2') },
     'load-more': { ...CONTENT, path: path('catering/load-more') },
+    reskin: { ...RESKIN, path: path('catering/reskin') },
   },
   'bizbash-lists': {
     lb1: { ...LB1, path: path('bizbash-lists/lb1') },
@@ -59,6 +62,7 @@ module.exports = {
     rail1: { ...CONTENT, path: path('bizbash-lists/rail1') },
     rail2: { ...CONTENT, path: path('bizbash-lists/rail2') },
     'load-more': { ...CONTENT, path: path('bizbash-lists/load-more') },
+    reskin: { ...RESKIN, path: path('bizbash-lists/reskin') },
   },
   'local-venues-destinations': {
     lb1: { ...LB1, path: path('local-venues-destinations/lb1') },
@@ -66,5 +70,14 @@ module.exports = {
     rail1: { ...CONTENT, path: path('local-venues-destinations/rail1') },
     rail2: { ...CONTENT, path: path('local-venues-destinations/rail2') },
     'load-more': { ...CONTENT, path: path('local-venues-destinations/load-more') },
+    reskin: { ...RESKIN, path: path('local-venues-destinations/reskin') },
+  },
+  gathergeeks: {
+    lb1: { ...LB1, path: path('gathergeeks/lb1') },
+    lb2: { ...LB2, path: path('gathergeeks/lb2') },
+    rail1: { ...CONTENT, path: path('gathergeeks/rail1') },
+    rail2: { ...CONTENT, path: path('gathergeeks/rail2') },
+    'load-more': { ...CONTENT, path: path('gathergeeks/load-more') },
+    reskin: { ...RESKIN, path: path('gathergeeks/reskin') },
   },
 };

--- a/sites/bizbash/server/routes/website-section.js
+++ b/sites/bizbash/server/routes/website-section.js
@@ -4,6 +4,9 @@ const submissionHandler = require('@endeavorb2b/base-website-common/utils/contac
 const section = require('../templates/website-section');
 const contactUsTemplate = require('../templates/website-section/contact-us');
 const gatherGeeksTemplate = require('../templates/website-section/gathergeeks');
+const productionStrategyTemplate = require('../templates/website-section/production-strategy');
+const styleDecorTemplate = require('../templates/website-section/style-decor');
+const cateringTemplate = require('../templates/website-section/catering');
 
 module.exports = (app) => {
   app.get('/:alias(contact-us)', withWebsiteSection({
@@ -14,6 +17,21 @@ module.exports = (app) => {
 
   app.get('/:alias(gathergeeks)', withWebsiteSection({
     template: gatherGeeksTemplate,
+    queryFragment,
+  }));
+
+  app.get('/:alias(production-strategy)', withWebsiteSection({
+    template: productionStrategyTemplate,
+    queryFragment,
+  }));
+
+  app.get('/:alias(style-decor)', withWebsiteSection({
+    template: styleDecorTemplate,
+    queryFragment,
+  }));
+
+  app.get('/:alias(catering)', withWebsiteSection({
+    template: cateringTemplate,
     queryFragment,
   }));
 

--- a/sites/bizbash/server/templates/website-section/catering.marko
+++ b/sites/bizbash/server/templates/website-section/catering.marko
@@ -22,16 +22,14 @@ $ const adSlots = {
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <div class="page-wrapper default-page">
-    <div class="row">
-      <div class="col">
-        <div class="page-wrapper__header">
-          <endeavor-breadcrumbs-website-section section=section />
-          <h1 class="page-wrapper__title">${section.name}</h1>
-          <if(section.description)>
-            <p class="page-wrapper__description">$!{section.description}</p>
-          </if>
-        </div>
+  <div class="row">
+    <div class="col">
+      <div class="page-wrapper__header">
+        <endeavor-breadcrumbs-website-section section=section />
+        <h1 class="page-wrapper__title">${section.name}</h1>
+        <if(section.description)>
+          <p class="page-wrapper__description">$!{section.description}</p>
+        </if>
       </div>
     </div>
   </div>

--- a/sites/bizbash/server/templates/website-section/catering.marko
+++ b/sites/bizbash/server/templates/website-section/catering.marko
@@ -1,0 +1,79 @@
+import { getAsObject } from '@base-cms/object-path';
+import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import hierarchyAliases from '@endeavorb2b/base-website-common/utils/website-section/hierarchy-aliases';
+
+$ const { site } = out.global;
+$ const section = getAsObject(data, 'section');
+$ const aliases = hierarchyAliases(section);
+$ const adSlots = {
+  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1', aliases }),
+  'gpt-ad-lb2': getAdUnit(site, { name: 'lb2', aliases }),
+  'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases, size: [300, 600] }),
+};
+
+<theme-default-website-section-layout section=section>
+  <@head>
+    <endeavor-ad-gam-head slots=adSlots />
+  </@head>
+
+  <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
+  </@above-container>
+
+  <website-scheduled-content-hero query={ sectionId: section.id, requiresImage: true }>
+    <@card-item|{ node }|>
+      <bizbash-hero-card content=node />
+    </@card-item>
+    <@list-item|{ node }|>
+      <bizbash-list-item content=node />
+    </@list-item>
+  </website-scheduled-content-hero>
+
+  <div class="row">
+    <div class="col-lg-12">
+      <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "catering/beverages", limit: 5 }>
+        <@header href="/catering/beverages">Beverages</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+    <div class="col-lg-4 ad-rail">
+      <endeavor-gam-ad-unit-display id="gpt-ad-rail1" />
+    </div>
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "catering/food-trends", limit: 5 }>
+        <@header href="/catering/food-trends">Food Trends</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+  </div>
+
+  <@below-container>
+    <endeavor-content-query-load-more
+      query={
+        skip: 5,
+        sectionId: section.id,
+      }
+      load-more={
+        maxPages: 0,
+      }
+      ads={ aliases }
+      native-x={ placement: 'card', aliases, index: 0 }
+    />
+  </@below-container>
+
+
+  <@footer>
+    <endeavor-gam-ad-sticky-leaderboard name="lb2" refreshable=true aliases=aliases />
+  </@footer>
+</theme-default-website-section-layout>

--- a/sites/bizbash/server/templates/website-section/catering.marko
+++ b/sites/bizbash/server/templates/website-section/catering.marko
@@ -18,21 +18,21 @@ $ const adSlots = {
 
   <@above-container>
     <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases  />
+    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <website-scheduled-content-hero query={ sectionId: section.id, requiresImage: true }>
-    <@card-item|{ node }|>
-      <bizbash-hero-card content=node />
-    </@card-item>
-    <@list-item|{ node }|>
-      <bizbash-list-item content=node />
-    </@list-item>
-  </website-scheduled-content-hero>
-
-  <div class="row">
-    <div class="col-lg-12">
-      <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+  <div class="page-wrapper default-page">
+    <div class="row">
+      <div class="col">
+        <div class="page-wrapper__header">
+          <endeavor-breadcrumbs-website-section section=section />
+          <h1 class="page-wrapper__title">${section.name}</h1>
+          <if(section.description)>
+            <p class="page-wrapper__description">$!{section.description}</p>
+          </if>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/sites/bizbash/server/templates/website-section/index.marko
+++ b/sites/bizbash/server/templates/website-section/index.marko
@@ -21,16 +21,14 @@ $ const adSlots = {
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <div class="page-wrapper default-page">
-    <div class="row">
-      <div class="col">
-        <div class="page-wrapper__header">
-          <endeavor-breadcrumbs-website-section section=section />
-          <h1 class="page-wrapper__title">${section.name}</h1>
-          <if(section.description)>
-            <p class="page-wrapper__description">$!{section.description}</p>
-          </if>
-        </div>
+  <div class="row">
+    <div class="col">
+      <div class="page-wrapper__header">
+        <endeavor-breadcrumbs-website-section section=section />
+        <h1 class="page-wrapper__title">${section.name}</h1>
+        <if(section.description)>
+          <p class="page-wrapper__description">$!{section.description}</p>
+        </if>
       </div>
     </div>
   </div>

--- a/sites/bizbash/server/templates/website-section/index.marko
+++ b/sites/bizbash/server/templates/website-section/index.marko
@@ -17,21 +17,21 @@ $ const adSlots = {
 
   <@above-container>
     <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases  />
+    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <website-scheduled-content-hero query={ sectionId: section.id, requiresImage: true }>
-    <@card-item|{ node }|>
-      <bizbash-hero-card content=node />
-    </@card-item>
-    <@list-item|{ node }|>
-      <bizbash-list-item content=node />
-    </@list-item>
-  </website-scheduled-content-hero>
-
-  <div class="row">
-    <div class="col-lg-12">
-      <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+  <div class="page-wrapper default-page">
+    <div class="row">
+      <div class="col">
+        <div class="page-wrapper__header">
+          <endeavor-breadcrumbs-website-section section=section />
+          <h1 class="page-wrapper__title">${section.name}</h1>
+          <if(section.description)>
+            <p class="page-wrapper__description">$!{section.description}</p>
+          </if>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/sites/bizbash/server/templates/website-section/production-strategy.marko
+++ b/sites/bizbash/server/templates/website-section/production-strategy.marko
@@ -22,16 +22,14 @@ $ const adSlots = {
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <div class="page-wrapper default-page">
-    <div class="row">
-      <div class="col">
-        <div class="page-wrapper__header">
-          <endeavor-breadcrumbs-website-section section=section />
-          <h1 class="page-wrapper__title">${section.name}</h1>
-          <if(section.description)>
-            <p class="page-wrapper__description">$!{section.description}</p>
-          </if>
-        </div>
+  <div class="row">
+    <div class="col">
+      <div class="page-wrapper__header">
+        <endeavor-breadcrumbs-website-section section=section />
+        <h1 class="page-wrapper__title">${section.name}</h1>
+        <if(section.description)>
+          <p class="page-wrapper__description">$!{section.description}</p>
+        </if>
       </div>
     </div>
   </div>

--- a/sites/bizbash/server/templates/website-section/production-strategy.marko
+++ b/sites/bizbash/server/templates/website-section/production-strategy.marko
@@ -1,0 +1,133 @@
+import { getAsObject } from '@base-cms/object-path';
+import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import hierarchyAliases from '@endeavorb2b/base-website-common/utils/website-section/hierarchy-aliases';
+
+$ const { site } = out.global;
+$ const section = getAsObject(data, 'section');
+$ const aliases = hierarchyAliases(section);
+$ const adSlots = {
+  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1', aliases }),
+  'gpt-ad-lb2': getAdUnit(site, { name: 'lb2', aliases }),
+  'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases, size: [300, 600] }),
+};
+
+<theme-default-website-section-layout section=section>
+  <@head>
+    <endeavor-ad-gam-head slots=adSlots />
+  </@head>
+
+  <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
+  </@above-container>
+
+  <website-scheduled-content-hero query={ sectionId: section.id, requiresImage: true }>
+    <@card-item|{ node }|>
+      <bizbash-hero-card content=node />
+    </@card-item>
+    <@list-item|{ node }|>
+      <bizbash-list-item content=node />
+    </@list-item>
+  </website-scheduled-content-hero>
+
+  <div class="row">
+    <div class="col-lg-12">
+      <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "production-strategy/audiovisual", limit: 5 }>
+        <@header href="/production-strategy/audiovisual">Audiovisual</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "production-strategy/event-management-tech-tools", limit: 5 }>
+        <@header href="/production-strategy/event-management-tech-tools">Event Management & Tech Tools</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "production-strategy/event-production-fabrication", limit: 5 }>
+        <@header href="/production-strategy/event-production-fabrication">Event Production & Fabrication</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "production-strategy/experiential-activations-sponsorships", limit: 5 }>
+        <@header href="/production-strategy/experiential-activations-sponsorships">Experiential, Activations & Sponsorships</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+    <div class="col-lg-4 ad-rail">
+      <endeavor-gam-ad-unit-display id="gpt-ad-rail1" />
+    </div>
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "production-strategy/opinion-experts", limit: 5 }>
+        <@header href="/production-strategy/opinion-experts">Opinion & Experts</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "production-strategy/programming-entertainment", limit: 5 }>
+        <@header href="/production-strategy/programming-entertainment">Programming & Entertainment</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "production-strategy/registration-ticketing", limit: 5 }>
+        <@header href="/production-strategy/registration-ticketing">Registration & Ticketing</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "production-strategy/strategy", limit: 5 }>
+        <@header href="/production-strategy/strategy">Strategy</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+  </div>
+
+  <@below-container>
+    <endeavor-content-query-load-more
+      query={
+        skip: 5,
+        sectionId: section.id,
+      }
+      load-more={
+        maxPages: 0,
+      }
+      ads={ aliases }
+      native-x={ placement: 'card', aliases, index: 0 }
+    />
+  </@below-container>
+
+
+  <@footer>
+    <endeavor-gam-ad-sticky-leaderboard name="lb2" refreshable=true aliases=aliases />
+  </@footer>
+</theme-default-website-section-layout>

--- a/sites/bizbash/server/templates/website-section/production-strategy.marko
+++ b/sites/bizbash/server/templates/website-section/production-strategy.marko
@@ -18,21 +18,21 @@ $ const adSlots = {
 
   <@above-container>
     <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases  />
+    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <website-scheduled-content-hero query={ sectionId: section.id, requiresImage: true }>
-    <@card-item|{ node }|>
-      <bizbash-hero-card content=node />
-    </@card-item>
-    <@list-item|{ node }|>
-      <bizbash-list-item content=node />
-    </@list-item>
-  </website-scheduled-content-hero>
-
-  <div class="row">
-    <div class="col-lg-12">
-      <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+  <div class="page-wrapper default-page">
+    <div class="row">
+      <div class="col">
+        <div class="page-wrapper__header">
+          <endeavor-breadcrumbs-website-section section=section />
+          <h1 class="page-wrapper__title">${section.name}</h1>
+          <if(section.description)>
+            <p class="page-wrapper__description">$!{section.description}</p>
+          </if>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/sites/bizbash/server/templates/website-section/style-decor.marko
+++ b/sites/bizbash/server/templates/website-section/style-decor.marko
@@ -22,16 +22,14 @@ $ const adSlots = {
     <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
   </@above-container>
 
-  <div class="page-wrapper default-page">
-    <div class="row">
-      <div class="col">
-        <div class="page-wrapper__header">
-          <endeavor-breadcrumbs-website-section section=section />
-          <h1 class="page-wrapper__title">${section.name}</h1>
-          <if(section.description)>
-            <p class="page-wrapper__description">$!{section.description}</p>
-          </if>
-        </div>
+  <div class="row">
+    <div class="col">
+      <div class="page-wrapper__header">
+        <endeavor-breadcrumbs-website-section section=section />
+        <h1 class="page-wrapper__title">${section.name}</h1>
+        <if(section.description)>
+          <p class="page-wrapper__description">$!{section.description}</p>
+        </if>
       </div>
     </div>
   </div>

--- a/sites/bizbash/server/templates/website-section/style-decor.marko
+++ b/sites/bizbash/server/templates/website-section/style-decor.marko
@@ -1,0 +1,133 @@
+import { getAsObject } from '@base-cms/object-path';
+import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
+import hierarchyAliases from '@endeavorb2b/base-website-common/utils/website-section/hierarchy-aliases';
+
+$ const { site } = out.global;
+$ const section = getAsObject(data, 'section');
+$ const aliases = hierarchyAliases(section);
+$ const adSlots = {
+  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1', aliases }),
+  'gpt-ad-lb2': getAdUnit(site, { name: 'lb2', aliases }),
+  'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases, size: [300, 600] }),
+};
+
+<theme-default-website-section-layout section=section>
+  <@head>
+    <endeavor-ad-gam-head slots=adSlots />
+  </@head>
+
+  <@above-container>
+    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
+    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases  />
+    <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+  </@above-container>
+
+  <div class="page-wrapper default-page">
+    <div class="row">
+      <div class="col">
+        <div class="page-wrapper__header">
+          <endeavor-breadcrumbs-website-section section=section />
+          <h1 class="page-wrapper__title">${section.name}</h1>
+          <if(section.description)>
+            <p class="page-wrapper__description">$!{section.description}</p>
+          </if>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "style-decor/event-design", limit: 5 }>
+        <@header href="/style-decor/event-design">Event Design</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "style-decor/floral", limit: 5 }>
+        <@header href="/style-decor/floral">Floral</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "style-decor/gifts-swag", limit: 5 }>
+        <@header href="/style-decor/gifts-swag">Gifts & Swag</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "style-decor/printing-graphics", limit: 5 }>
+        <@header href="/style-decor/printing-graphics">Printing & Graphics</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+    <div class="col-lg-4 ad-rail">
+      <endeavor-gam-ad-unit-display id="gpt-ad-rail1" />
+    </div>
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "style-decor/rentals", limit: 5 }>
+        <@header href="/style-decor/rentals">Rentals</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "style-decor/social-events", limit: 5 }>
+        <@header href="/style-decor/social-events">Social Events</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "style-decor/tabletop", limit: 5 }>
+        <@header href="/style-decor/tabletop">Tabletop</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+    <div class="col-lg-4 mb-block">
+      <website-scheduled-content-list query={ sectionAlias: "production-strategy/strategy", limit: 5 }>
+        <@header href="/production-strategy/strategy">Strategy</@header>
+        <@item|{ node }|>
+          <bizbash-list-item content=node />
+        </@item>
+      </website-scheduled-content-list>
+    </div>
+  </div>
+
+  <@below-container>
+    <endeavor-content-query-load-more
+      query={
+        skip: 5,
+        sectionId: section.id,
+      }
+      load-more={
+        maxPages: 0,
+      }
+      ads={ aliases }
+      native-x={ placement: 'card', aliases, index: 0 }
+    />
+  </@below-container>
+
+
+  <@footer>
+    <endeavor-gam-ad-sticky-leaderboard name="lb2" refreshable=true aliases=aliases />
+  </@footer>
+</theme-default-website-section-layout>


### PR DESCRIPTION
- Custom layouts for channel pages
- Changed default website section layout to use section name and description in place of hero
- Ad unit updates (added GatherGeeks, reskin for all)

<img width="1216" alt="Screen Shot 2019-07-24 at 9 10 09 AM" src="https://user-images.githubusercontent.com/2855198/61800583-e6f4bb00-adf2-11e9-8539-e7019fe64bb7.png">
