### PR TITLE
CS2586-LFW-BTR: added On Topic block to indexes

### DIFF
--- a/sites/broadbandtechreport/server/templates/index.marko
+++ b/sites/broadbandtechreport/server/templates/index.marko
@@ -113,11 +113,11 @@ $ const adSlots = {
     <div class="col-lg-4 mb-block">
       <endeavor-published-content-query-list
         query={
-          contentTypes: ["Whitepaper", "Webinar"],
+          contentTypes: ["Whitepaper"],
           limit: 4,
         }
         with-image=false
-        header={ title: "White Papers & Webinars", href: "/white-papers" }
+        header={ title: "White Papers", href: "/white-papers" }
       />
     </div>
     <div class="col-lg-4 mb-block">
@@ -127,6 +127,34 @@ $ const adSlots = {
           limit: 4,
         }
         header={ title: "Videos", href: "/videos" }
+      />
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-4 mb-block">
+      <endeavor-content-query-section-list
+        limit=4
+        section-alias="on-topic"
+        header={ title: "On Topic", href: "/on-topic" }
+      />
+    </div>
+    <div class="col-lg-4 mb-block">
+      <endeavor-published-content-query-list
+        query={
+          contentTypes: ["Webinar"],
+          limit: 4,
+        }
+        with-image=false
+        header={ title: "Webinars", href: "/webcasts" }
+      />
+    </div>
+    <div class="col-lg-4 mb-block">
+      <endeavor-content-query-section-list
+        limit=4
+        skip=4
+        section-alias=section.alias
+        header={ title: `More from ${out.global.config.siteName()}` }
       />
     </div>
   </div>

--- a/sites/lightwaveonline/server/templates/index.marko
+++ b/sites/lightwaveonline/server/templates/index.marko
@@ -145,7 +145,14 @@ $ const adSlots = {
         header={ title: "Videos", href: "/videos" }
       />
     </div>
-    <div class="col-lg-8 mb-block">
+    <div class="col-lg-4 mb-block">
+      <endeavor-content-query-section-list
+        limit=5
+        section-alias="on-topic"
+        header={ title: "On Topic", href: "/on-topic" }
+      />
+    </div>
+    <div class="col-lg-4 mb-block">
       <endeavor-content-query-section-list
         limit=5
         skip=5


### PR DESCRIPTION
https://southcomm.atlassian.net/projects/CS/queues/custom/11/CS-2586

on lightwave, reducing the “More” block from two spaces to one, and adding in the On Topic. on btr, splitting out the whitepaper/webinar combined section, adding a “more”, and add the On Topic section.

LW Before:
<img width="1211" alt="Screen Shot 2019-07-25 at 2 43 09 PM" src="https://user-images.githubusercontent.com/6343242/61903635-93659880-aeea-11e9-9b50-f07c731dc4bb.png">

LW After:
<img width="1205" alt="Screen Shot 2019-07-25 at 2 13 46 PM" src="https://user-images.githubusercontent.com/6343242/61903717-d4f64380-aeea-11e9-9f13-e6b64d9e000d.png">

BTR Before:
<img width="1204" alt="Screen Shot 2019-07-25 at 2 04 12 PM" src="https://user-images.githubusercontent.com/6343242/61903666-b09a6700-aeea-11e9-9837-09b48f4a150f.png">

BTR After:
-- NOTE: BTR does not currently have any content scheduled to https://www.broadbandtechreport.com/on-topic
<img width="1200" alt="Screen Shot 2019-07-25 at 2 51 03 PM" src="https://user-images.githubusercontent.com/6343242/61904075-b0e73200-aeeb-11e9-91fc-8724dfd75991.png">

<img width="1176" alt="Screen Shot 2019-07-25 at 2 51 13 PM" src="https://user-images.githubusercontent.com/6343242/61904125-ccead380-aeeb-11e9-85f5-5d2ebc429ca1.png">



