### PR TITLE
Content page date format & CSS attribution prefixes

### DIFF
--- a/packages/common/components/content/blocks/item.marko
+++ b/packages/common/components/content/blocks/item.marko
@@ -50,10 +50,10 @@ $ if (userRegistration.isRequired && identityX) titleModifiers.push('locked');
     </if>
     <@footer-left|{ block }|>
       <if(company.id)>
-        <endeavor-content-company-name use-prefix=false company=company />
+        <endeavor-content-company-name company=company />
       </if>
       <else>
-        <endeavor-content-authors block=block use-prefix=false content=content />
+        <endeavor-content-authors block=block content=content />
       </else>
     </@footer-left>
     <@footer-right|{ block }|>

--- a/packages/common/components/content/blocks/marko.json
+++ b/packages/common/components/content/blocks/marko.json
@@ -51,7 +51,8 @@
       "@content": {
         "type": "object",
         "required": true
-      }
+      },
+      "@date-format": "string"
     },
     "endeavor-content-block-page-body": {
       "template": "./page-body.marko",

--- a/packages/common/components/content/blocks/page-header.marko
+++ b/packages/common/components/content/blocks/page-header.marko
@@ -7,15 +7,15 @@ $ const noPublishDateContentTypes = ['event', 'webinar', 'contact'];
 <cms-content-name tag="h1" class="page-wrapper__title" obj=input.content />
 <cms-content-teaser tag="p" class="page-wrapper__deck" obj=input.content />
 <if(content.type === 'event')>
-    <endeavor-content-starts block="item" obj=input.content />
-    <endeavor-content-ends block="item" obj=input.content/>
+    <endeavor-content-starts block="item" obj=input.content format=input.dateFormat />
+    <endeavor-content-ends block="item" obj=input.content format=input.dateFormat />
 </if>
 <if(content.type === 'webinar')>
-    <endeavor-content-starts block="item" obj=input.content/>
+    <endeavor-content-starts block="item" obj=input.content format=input.dateFormat />
 </if>
 <if(content.type !== 'contact')>
   <endeavor-content-block-attribution content=input.content />
 </if>
 <if(!noPublishDateContentTypes.includes(content.type))>
-  <cms-content-published class="content-published-date" obj=input.content />
+  <cms-content-published class="content-published-date" obj=input.content format=input.dateFormat />
 </if>

--- a/packages/common/components/content/elements/authors.marko
+++ b/packages/common/components/content/elements/authors.marko
@@ -1,18 +1,9 @@
-$ const prefixClass = `${input.block}__prefix`;
-
 <cms-content-authors|{ contact }|
   tag=input.tag
   class=input.class
   block=input.block
   obj=input.content
 >
-  <@before|{ length }|>
-    <if(input.usePrefix)>
-      <span class=prefixClass>
-        ${input.prefix}<if(length > 1)>s</if>
-      </span>
-    </if>
-  </@before>
   <cms-content-name
     tag=input.itemTag
     class=input.itemClass

--- a/packages/common/components/content/elements/byline.marko
+++ b/packages/common/components/content/elements/byline.marko
@@ -1,14 +1,6 @@
-$ const prefixClass = `${input.block}__prefix`;
-
 <cms-content-byline
   tag=input.tag
   class=input.class
   block=input.block
   obj=input.content
->
-  <@before>
-    <span class=prefixClass>
-      ${input.prefix}
-    </span>
-  </@before>
-</cms-content-byline>
+/>

--- a/packages/common/components/content/elements/company-name.marko
+++ b/packages/common/components/content/elements/company-name.marko
@@ -1,5 +1,3 @@
-$ const prefixClass = `${input.block}__prefix`;
-
 <cms-content-name
   tag=input.tag
   class=input.class
@@ -7,12 +5,4 @@ $ const prefixClass = `${input.block}__prefix`;
   modifiers=['company-name']
   obj=input.company
   link=true
->
-  <@before>
-    <if(input.usePrefix)>
-      <span class=prefixClass>
-        ${input.prefix}
-      </span>
-    </if>
-  </@before>
-</cms-content-name>
+/>

--- a/packages/common/components/content/elements/contributors.marko
+++ b/packages/common/components/content/elements/contributors.marko
@@ -1,16 +1,9 @@
-$ const prefixClass = `${input.block}__prefix`;
-
 <cms-content-contributors|{ contact }|
   tag=input.tag
   class=input.class
   block=input.block
   obj=input.content
 >
-  <@before|{ length }|>
-    <span class=prefixClass>
-      ${input.prefix}<if(length > 1)>s</if>
-    </span>
-  </@before>
   <cms-content-name
     tag=input.itemTag
     class=input.itemClass

--- a/packages/common/components/content/elements/marko.json
+++ b/packages/common/components/content/elements/marko.json
@@ -15,15 +15,6 @@
       "@block": {
         "type": "string"
       },
-      "@prefix": {
-        "type": "string",
-        "required": true,
-        "default-value": "Author"
-      },
-      "@use-prefix": {
-        "type": "boolean",
-        "default-value": true
-      },
       "@class": "string",
       "@itemClass": "string",
       "@tag": {
@@ -43,15 +34,6 @@
       },
       "@block": {
         "type": "string"
-      },
-      "@prefix": {
-        "type": "string",
-        "required": true,
-        "default-value": "Contributor"
-      },
-      "@use-prefix": {
-        "type": "boolean",
-        "default-value": true
       },
       "@class": "string",
       "@itemClass": "string",
@@ -73,15 +55,6 @@
       "@block": {
         "type": "string"
       },
-      "@prefix": {
-        "type": "string",
-        "required": true,
-        "default-value": "Photographer"
-      },
-      "@use-prefix": {
-        "type": "boolean",
-        "default-value": true
-      },
       "@class": "string",
       "@itemClass": "string",
       "@tag": {
@@ -102,15 +75,6 @@
       "@block": {
         "type": "string"
       },
-      "@prefix": {
-        "type": "string",
-        "required": true,
-        "default-value": "Source"
-      },
-      "@use-prefix": {
-        "type": "boolean",
-        "default-value": true
-      },
       "@class": "string",
       "@tag": {
         "type": "string",
@@ -126,15 +90,6 @@
       },
       "@block": {
         "type": "string"
-      },
-      "@prefix": {
-        "type": "string",
-        "required": true,
-        "default-value": "By"
-      },
-      "@use-prefix": {
-        "type": "boolean",
-        "default-value": true
       },
       "@class": "string",
       "@tag": {
@@ -152,15 +107,6 @@
       "@block": {
         "type": "string"
       },
-      "@prefix": {
-        "type": "string",
-        "required": true,
-        "default-value": "From"
-      },
-      "@use-prefix": {
-        "type": "boolean",
-        "default-value": true
-      },
       "@class": "string",
       "@tag": {
         "type": "string",
@@ -176,15 +122,6 @@
       },
       "@block": {
         "type": "string"
-      },
-      "@prefix": {
-        "type": "string",
-        "required": true,
-        "default-value": "Sponsor"
-      },
-      "@use-prefix": {
-        "type": "boolean",
-        "default-value": true
       },
       "@class": "string",
       "@itemClass": "string",

--- a/packages/common/components/content/elements/photographers.marko
+++ b/packages/common/components/content/elements/photographers.marko
@@ -1,16 +1,9 @@
-$ const prefixClass = `${input.block}__prefix`;
-
 <cms-content-photographers|{ contact }|
   tag=input.tag
   class=input.class
   block=input.block
   obj=input.content
 >
-  <@before|{ length }|>
-    <span class=prefixClass>
-      ${input.prefix}<if(length > 1)>s</if>
-    </span>
-  </@before>
   <cms-content-name
     tag=input.itemTag
     class=input.itemClass

--- a/packages/common/components/content/elements/source.marko
+++ b/packages/common/components/content/elements/source.marko
@@ -1,14 +1,6 @@
-$ const prefixClass = `${input.block}__prefix`;
-
 <cms-content-source
   tag=input.tag
   class=input.class
   block=input.block
   obj=input.content
->
-  <@before>
-    <span class=prefixClass>
-      ${input.prefix}
-    </span>
-  </@before>
-</cms-content-source>
+/>

--- a/packages/common/components/content/elements/sponsors.marko
+++ b/packages/common/components/content/elements/sponsors.marko
@@ -1,18 +1,9 @@
-$ const prefixClass = `${input.block}__prefix`;
-
 <cms-content-sponsors|{ contact }|
   tag=input.tag
   class=input.class
   block=input.block
   obj=input.content
 >
-  <@before|{ length }|>
-    <if(input.usePrefix)>
-      <span class=prefixClass>
-        ${input.prefix}<if(length > 1)>s</if>
-      </span>
-    </if>
-  </@before>
   <cms-content-name
     tag=input.itemTag
     class=input.itemClass

--- a/packages/themes/default/styles/theme/content/_attribution.scss
+++ b/packages/themes/default/styles/theme/content/_attribution.scss
@@ -1,19 +1,88 @@
 .content-attribution {
+  $self: &;
   font-family: $theme-content-attribution-font-family;
   font-size: $theme-content-attribution-font-size;
   font-weight: $theme-content-attribution-font-weight;
   line-height: $theme-content-attribution-line-height;
   color: $theme-content-attribution-color;
   text-transform: $theme-content-attribution-text-transform;
-  &__prefix {
-    margin-right: $theme-content-attribution-prefix-margin;
-    font-weight: $theme-content-attribution-prefix-font-weight;
-    &::after {
-      margin-left: $theme-content-attribution-prefix-margin-after;
-      font-weight: $theme-content-attribution-prefix-spacer-font-weight;
-      content: $theme-content-attribution-prefix-spacer-content;
+
+  &__content-authors {
+    &::before {
+      margin-right: $theme-content-attribution-prefix-margin;
+      font-weight: $theme-content-attribution-prefix-font-weight;
+      content: "Author";
     }
   }
+
+  &__content-byline {
+    &::before {
+      margin-right: $theme-content-attribution-prefix-margin;
+      font-weight: $theme-content-attribution-prefix-font-weight;
+      content: "By";
+    }
+  }
+
+  &__content-company-name {
+    &::before {
+      margin-right: $theme-content-attribution-prefix-margin;
+      font-weight: $theme-content-attribution-prefix-font-weight;
+      content: "From";
+    }
+  }
+
+  &__content-contributors {
+    &::before {
+      margin-right: $theme-content-attribution-prefix-margin;
+      font-weight: $theme-content-attribution-prefix-font-weight;
+      content: "Contributor";
+    }
+  }
+
+  &__content-photographers {
+    &::before {
+      margin-right: $theme-content-attribution-prefix-margin;
+      font-weight: $theme-content-attribution-prefix-font-weight;
+      content: "Photographer";
+    }
+  }
+
+  &__content-source {
+    &::before {
+      margin-right: $theme-content-attribution-prefix-margin;
+      font-weight: $theme-content-attribution-prefix-font-weight;
+      content: "Source";
+    }
+  }
+
+  &__content-sponsor {
+    &::before {
+      margin-right: $theme-content-attribution-prefix-margin;
+      font-weight: $theme-content-attribution-prefix-font-weight;
+      content: "Sponsor";
+    }
+  }
+
+  &__content-authors,
+  &__content-byline,
+  &__content-company-name,
+  &__content-contributors,
+  &__content-photographers,
+  &__content-source,
+  &__content-sponsor {
+    #{ $self } {
+      &__content-name {
+        &:first-child {
+          &::before {
+            margin-right: $theme-content-attribution-prefix-margin-after;
+            font-weight: $theme-content-attribution-prefix-spacer-font-weight;
+            content: $theme-content-attribution-prefix-spacer-content;
+          }
+        }
+      }
+    }
+  }
+
   &__content-name {
     margin-right: $theme-content-attribution-name-margin;
     &::after {

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -413,6 +413,11 @@ body {
   div {
     display: inline;
   }
+  &__content-authors {
+    &::before {
+      content: "By";
+    }
+  }
 }
 
 .content-attribution:not(:empty) + .content-published-date {

--- a/sites/bizbash/server/templates/content/index.marko
+++ b/sites/bizbash/server/templates/content/index.marko
@@ -29,7 +29,7 @@ $ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.t
     <div class="row">
       <div class="col">
         <div class="page-wrapper__header">
-          <endeavor-content-block-page-header content=content />
+          <endeavor-content-block-page-header content=content date-format="MMMM D, YYYY" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
- support passing `date-format` to content page header
- defer content attribution prefixes to CSS (as opposed to text `<@before>` calls)

Bizbash specific:
- set proper date format
- change `authors` prefix from "Author" to "By"