### PR TITLE
Add directly related content to content pages

### DIFF
--- a/sites/bizbash/components/marko.json
+++ b/sites/bizbash/components/marko.json
@@ -3,6 +3,25 @@
     "./load-more/marko.json"
   ],
   "tags": {
+    "bizbash-related-content": {
+      "template": "./related-content.marko",
+      "@content-id": {
+        "type": "number",
+        "required": true
+      },
+      "@content-type": {
+        "type": "string",
+        "required": true
+      },
+      "@section-id": {
+        "type": "number",
+        "required": true
+      },
+      "@section-name": {
+        "type": "string",
+        "required": true
+      }
+    },
     "bizbash-image-slider": {
       "template": "./image-slider.marko"
     },

--- a/sites/bizbash/components/related-content.marko
+++ b/sites/bizbash/components/related-content.marko
@@ -1,0 +1,24 @@
+import contentListFragment from '@endeavorb2b/base-website-common/api/fragments/content-list';
+
+<cms-query-related-published-content|{ nodes }| limit=10 content-id=input.contentId query-fragment=contentListFragment>
+  <if(nodes.length)>
+    <endeavor-item-list modifiers=["unjustified"] items=nodes>
+      <@header>Related</@header>
+      <@item|{ item }|>
+        <bizbash-list-item content=item />
+      </@item>
+    </endeavor-item-list>
+  </if>
+</cms-query-related-published-content>
+
+<if(!['contact', 'company'].includes(input.contentType))>
+  <website-scheduled-content-list
+    query={ sectionId: input.sectionId, excludeContentIds: [input.contentId], limit: 5 }
+    item-list={ modifiers: ["unjustified"] }
+  >
+    <@header>Latest in ${input.sectionName}</@header>
+    <@item|{ node }|>
+      <bizbash-list-item content=node />
+    </@item>
+  </website-scheduled-content-list>
+</if>

--- a/sites/bizbash/server/templates/content/index.marko
+++ b/sites/bizbash/server/templates/content/index.marko
@@ -38,20 +38,14 @@ $ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.t
       <div class="col-lg-8">
         <endeavor-content-block-page-body content=content display-primary-image=displayPrimaryImage />
       </div>
-
       <aside class="col-lg-4 page-right-rail">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" />
-        <if(!['contact', 'company'].includes(content.type))>
-          <website-scheduled-content-list
-            query={ sectionId: section.id, excludeContentIds: [content.id], limit: 5 }
-            item-list={ modifiers: ["unjustified"] }
-          >
-            <@header>Related</@header>
-            <@item|{ node }|>
-              <bizbash-list-item content=node />
-            </@item>
-          </website-scheduled-content-list>
-        </if>
+        <bizbash-related-content
+          content-id=content.id
+          content-type=content.type
+          section-id=section.id
+          section-name=section.name
+        />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" />
       </aside>
     </div>

--- a/sites/bizbash/server/templates/content/top-list.marko
+++ b/sites/bizbash/server/templates/content/top-list.marko
@@ -46,15 +46,12 @@ $ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.t
 
       <aside class="col-lg-4 page-right-rail">
         <endeavor-gam-ad-unit-display id="gpt-ad-rail1" />
-        <website-scheduled-content-list
-          query={ sectionId: section.id, excludeContentIds: [content.id], limit: 5 }
-          item-list={ modifiers: ["unjustified"] }
-        >
-          <@header>Related</@header>
-          <@item|{ node }|>
-            <bizbash-list-item content=node />
-          </@item>
-        </website-scheduled-content-list>
+        <bizbash-related-content
+          content-id=content.id
+          content-type=content.type
+          section-id=section.id
+          section-name=section.name
+        />
         <endeavor-gam-ad-unit-display id="gpt-ad-rail2" />
       </aside>
     </div>


### PR DESCRIPTION
- create common `<bizbash-related-content>` component
- display both directly and primary section related content blocks

![image](https://user-images.githubusercontent.com/3289485/61958624-484d9300-af87-11e9-8c45-a95fb4119a06.png)
