### PR TITLE
CS2709-VSD: updated homepage content blocks

### DIFF
--- a/sites/vision-systems/server/templates/index.marko
+++ b/sites/vision-systems/server/templates/index.marko
@@ -140,7 +140,7 @@ $ const adSlots = {
         query={
           requiresImage: false,
           contentTypes: ["Video"],
-          limit: 5,
+          limit: 4,
         }
         header={ title: "Videos", href: "/videos" }
       />
@@ -148,9 +148,8 @@ $ const adSlots = {
     <div class="col-lg-4 mb-block">
       <endeavor-content-query-section-list
         limit=4
-        skip=5
-        section-alias=section.alias
-        header={ title: `More from ${out.global.config.siteName()}` }
+        section-alias="blogs"
+        header={ title: "Commentary", href: "/blogs" }
       />
     </div>
     <div class="col-lg-4 mb-block">


### PR DESCRIPTION
Replaced “More” with “Commentary” (blogs)
Reduce limit from 5 to 4, as blogs have really long titles, and there was a big empty white space below the current issue

https://southcomm.atlassian.net/projects/CS/queues/custom/12/CS-2709

Before:
<img width="1197" alt="Screen Shot 2019-07-26 at 11 34 02 AM" src="https://user-images.githubusercontent.com/6343242/61966973-c5820380-af99-11e9-930e-fafc1948f14f.png">

After:
<img width="1194" alt="Screen Shot 2019-07-26 at 11 33 17 AM" src="https://user-images.githubusercontent.com/6343242/61966993-d16dc580-af99-11e9-843c-581c7ec77046.png">
