### PR TITLE
CS2712-BOW: updated homepage content blocks

### DIFF
--- a/sites/bioopticsworld/server/templates/index.marko
+++ b/sites/bioopticsworld/server/templates/index.marko
@@ -109,12 +109,10 @@ $ const adSlots = {
 
   <div class="row">
     <div class="col-lg-4 mb-block">
-      <endeavor-published-content-query-list
-        query={
-          contentTypes: ["Video"],
-          limit: 4,
-        }
-        header={ title: "Videos", href: "/videos" }
+      <endeavor-content-query-section-list
+        limit=4
+        section-alias="blogs"
+        header={ title: "Commentary", href: "/commentary" }
       />
     </div>
     <div class="col-lg-4 mb-block">


### PR DESCRIPTION
Replaced “Videos” with “Commentary”

https://southcomm.atlassian.net/projects/CS/queues/custom/12/CS-2712

Before:
<img width="1218" alt="Screen Shot 2019-07-26 at 11 43 38 AM" src="https://user-images.githubusercontent.com/6343242/61967398-ccf5dc80-af9a-11e9-988a-e2a12b81f0da.png">

After:
<img width="1201" alt="Screen Shot 2019-07-26 at 11 43 09 AM" src="https://user-images.githubusercontent.com/6343242/61967409-d3845400-af9a-11e9-885a-edcc360e4103.png">

