### PR TITLE
CS2710-ILS: updated homepage content blocks

### DIFF
--- a/sites/industrial-lasers/server/templates/index.marko
+++ b/sites/industrial-lasers/server/templates/index.marko
@@ -103,12 +103,10 @@ $ const adSlots = {
 
   <div class="row">
     <div class="col-lg-4 mb-block">
-      <endeavor-published-content-query-list
-        query={
-          contentTypes: ["Video"],
-          limit: 5,
-        }
-        header={ title: "Videos", href: "/videos" }
+      <endeavor-content-query-section-list
+        limit=5
+        section-alias="commentary"
+        header={ title: "Commentary", href: "/commentary" }
       />
     </div>
     <div class="col-lg-4 mb-block">


### PR DESCRIPTION
Replaces “Videos” with “Commentary”

https://southcomm.atlassian.net/projects/CS/queues/custom/12/CS-2710

Before:
<img width="1189" alt="Screen Shot 2019-07-26 at 11 50 14 AM" src="https://user-images.githubusercontent.com/6343242/61967665-9a001880-af9b-11e9-8e0a-f68c3ded681c.png">

After:
<img width="1193" alt="Screen Shot 2019-07-26 at 11 49 32 AM" src="https://user-images.githubusercontent.com/6343242/61967692-a2f0ea00-af9b-11e9-94e4-3b62fd6345ab.png">
