### PR TITLE
CS2713-LFW: added contentBlocks on homepage

### DIFF
--- a/sites/laserfocusworld/server/templates/index.marko
+++ b/sites/laserfocusworld/server/templates/index.marko
@@ -134,6 +134,31 @@ $ const adSlots = {
     </div>
   </div>
 
+  <div class="row">
+    <div class="col-lg-4 mb-block">
+      <endeavor-content-query-section-list
+        limit=3
+        section-alias="blogs"
+        header={ title: "Commentary" , href: "/blogs" }
+      />
+    </div>
+    <div class="col-lg-4 mb-block">
+      <endeavor-content-query-section-list
+        limit=3
+        skip=4
+        section-alias=section.alias
+        header={ title: `More from ${out.global.config.siteName()}` }
+      />
+    </div>
+    <div class="col-lg-4 mb-block">
+      <endeavor-content-query-section-list
+        limit=3
+        section-alias="optics/optics-design"
+        header={ title: "Optics & Design" , href: "/optics/optics-design" }
+      />
+    </div>
+  </div>
+
   <@below-container>
     <endeavor-content-query-load-more
       query={


### PR DESCRIPTION
Added row on homepage for Commentary, More, and Optics & Design

https://southcomm.atlassian.net/projects/CS/queues/custom/12/CS-2713

Added:
<img width="1197" alt="Screen Shot 2019-07-26 at 12 04 03 PM" src="https://user-images.githubusercontent.com/6343242/61968532-e4829480-af9d-11e9-88e1-4f1702173081.png">
