### PR TITLE
Disable attribution on venue/supplier pages

### DIFF
--- a/sites/bizbash/server/templates/content/supplier.marko
+++ b/sites/bizbash/server/templates/content/supplier.marko
@@ -30,7 +30,9 @@ $ const images = getAsArray(content, 'images.edges').map(({ node }) => node);
       <div class="col">
         <div class="page-wrapper__header">
           <bizbash-image-slider images=images />
-          <endeavor-content-block-page-header content=content />
+          <endeavor-breadcrumbs-website-section section=content.primarySection />
+          <cms-content-name tag="h1" class="page-wrapper__title" obj=content />
+          <cms-content-teaser tag="p" class="page-wrapper__deck" obj=content />
         </div>
       </div>
     </div>

--- a/sites/bizbash/server/templates/content/top-list.marko
+++ b/sites/bizbash/server/templates/content/top-list.marko
@@ -30,7 +30,7 @@ $ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.t
     <div class="row">
       <div class="col">
         <div class="page-wrapper__header">
-          <endeavor-content-block-page-header content=content />
+          <endeavor-content-block-page-header content=content date-format="MMMM D, YYYY" />
         </div>
       </div>
     </div>

--- a/sites/bizbash/server/templates/content/venue.marko
+++ b/sites/bizbash/server/templates/content/venue.marko
@@ -31,7 +31,9 @@ $ const spaces = getAsArray(content, 'spaces.edges').map(({ node }) => node);
       <div class="col">
         <div class="page-wrapper__header">
           <bizbash-image-slider images=images />
-          <endeavor-content-block-page-header content=content />
+          <endeavor-breadcrumbs-website-section section=content.primarySection />
+          <cms-content-name tag="h1" class="page-wrapper__title" obj=content />
+          <cms-content-teaser tag="p" class="page-wrapper__deck" obj=content />
         </div>
       </div>
     </div>


### PR DESCRIPTION
And set proper date format on content top list pages. This also removes displaying the Company name/link on supplier pages (which we don't want)

Published dates were also removed from venues and suppliers, as they don't make sense on those pages.