### PR TITLE
Preserve left and right margin on embedded media

### DIFF
--- a/packages/themes/default/styles/theme/_embedded-media.scss
+++ b/packages/themes/default/styles/theme/_embedded-media.scss
@@ -10,7 +10,8 @@
 
 .content-body-contents {
   p:first-child [data-embed-type] {
-    margin: 0;
+    margin-top: 0;
+    margin-bottom: 0;
   }
 }
 


### PR DESCRIPTION
When inside the first paragraph on the page