### PR TITLE
Add generic story/listing/gallery redirect handler

### DIFF
--- a/sites/bizbash/index.js
+++ b/sites/bizbash/index.js
@@ -17,4 +17,10 @@ module.exports = startServer({
   errorTemplate,
   onStart: onStart(version),
   onAsyncBlockError: e => newrelic.noticeError(e),
+  redirectHandler: ({ from }) => {
+    const pattern = /(\/story\/[0-9]*|\/listing\/[0-9]*|\/gallery\/[0-9]*)/;
+    const matches = pattern.exec(from);
+    if (!matches || !matches[0]) return null;
+    return { to: matches[0] };
+  },
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));


### PR DESCRIPTION
Incoming paths that contain `/story/{id}`, `/listing/{id}`, or `/gallery/{id}` will redirect to the matched pattern.

For example: `/call_sheet_70_hotel_buyers_from_abroad_event_planners_aid_katrina_victims_affordable_same-sex_wedding_start-up/new-york/story/21181/` will be redirected to `/story/21181` that, in turn, will be redirected to the correct article via the `Redirects` collection.