### PR TITLE
Set IdentityX info to dataLayer, if present

### DIFF
--- a/packages/themes/default/components/document.marko
+++ b/packages/themes/default/components/document.marko
@@ -13,18 +13,17 @@ import { getAsObject } from '@base-cms/object-path';
 
   <identity-x|{ isEnabled, mergedTeams, user }|>
     <if(isEnabled)>
-      $ const { id: identityXTeamId, name: identityXTeamName } = getAsObject(mergedTeams, 0);
-      $ const { id: identityXUserId, email: identityXUserEmail } = user || {};
-      <if (identityXUserId || identityXTeamId)>
+      $ const { id: identityx_team_id, name: identityx_team_name } = getAsObject(mergedTeams, 0);
+      $ const { id: identityx_user_id, email: identityx_user_email } = user || {};
+      <if (identityx_user_id || identityx_team_id)>
+        $ const gtmArgs = JSON.stringify({
+          identityx_user_id,
+          identityx_user_email,
+          identityx_team_id,
+          identityx_team_name,
+        });
         <script>
-          if (window.dataLayer) {
-            window.dataLayer.push({
-              identityXUserId: ${identityXUserId ? `'${identityXUserId}'` : 'undefined'},
-              identityXUserEmail: ${identityXUserEmail ? `'${identityXUserEmail}'` : 'undefined'},
-              identityXTeamId: ${identityXTeamId ? `'${identityXTeamId}'` : 'undefined'},
-              identityXTeamName: ${identityXTeamName ? `'${identityXTeamName}'` : 'undefined'},
-            });
-          }
+          if (window.dataLayer) window.dataLayer.push(${gtmArgs});
         </script>
       </if>
     </if>

--- a/packages/themes/default/components/document.marko
+++ b/packages/themes/default/components/document.marko
@@ -1,3 +1,5 @@
+import { getAsObject } from '@base-cms/object-path';
+
 <cms-document ...input>
   <@head>
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -8,6 +10,25 @@
     <${input.head} />
   </@head>
   <cms-browser-component name="ReskinListener" />
+
+  <identity-x|{ isEnabled, mergedTeams, user }|>
+    <if(isEnabled)>
+      $ const { id: identityXTeamId, name: identityXTeamName } = getAsObject(mergedTeams, 0);
+      $ const { id: identityXUserId, email: identityXUserEmail } = user || {};
+      <if (identityXUserId || identityXTeamId)>
+        <script>
+          if (window.dataLayer) {
+            window.dataLayer.push({
+              identityXUserId: ${identityXUserId ? `'${identityXUserId}'` : 'undefined'},
+              identityXUserEmail: ${identityXUserEmail ? `'${identityXUserEmail}'` : 'undefined'},
+              identityXTeamId: ${identityXTeamId ? `'${identityXTeamId}'` : 'undefined'},
+              identityXTeamName: ${identityXTeamName ? `'${identityXTeamName}'` : 'undefined'},
+            });
+          }
+        </script>
+      </if>
+    </if>
+  </identity-x>
 
   <if(input.navbar)>
     <${input.navbar} />

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@base-cms/marko-web": "^0.9.49",
     "@endeavorb2b/base-website-common": "^0.12.13",
+    "@endeavorb2b/base-website-identity-x": "^0.12.13",
     "bootstrap": "4.3.1",
     "graphql": "^14.3.1",
     "graphql-tag": "^2.10.1"


### PR DESCRIPTION
Allows data to be consumed within GTM, specifically to send the team name to GA for OGJ as a custom dimension.

When IdentityX is disabled, or no team or user context is available, nothing is done. If those conditions are met, the data is appended to the dataLayer. This is in the default theme's document template for now, until later refactoring is completed.

<img width="933" alt="Screen Shot 2019-07-31 at 2 53 02 PM" src="https://user-images.githubusercontent.com/1778222/62243506-05365a00-b3a3-11e9-84f4-2640e14b4713.png">
<img width="933" alt="Screen Shot 2019-07-31 at 2 53 16 PM" src="https://user-images.githubusercontent.com/1778222/62243507-05365a00-b3a3-11e9-84b9-939281bab52c.png">
