### PR TITLE
Refactor-Navbar-Themes

### DIFF
--- a/packages/themes/default/styles/_functions.scss
+++ b/packages/themes/default/styles/_functions.scss
@@ -1,17 +1,17 @@
 @import "../../node_modules/bootstrap/scss/functions";
 
+@function map-deep-get($map, $keys...) {
+  @each $key in $keys {
+      $map: map-get($map, $key);
+  }
+  @return $map;
+}
+
 @function get-line-height($font-size-px, $line-height-px) {
   @if $line-height-px < $font-size-px {
     @return 1;
   }
   @return $line-height-px / $font-size-px;
-}
-
-@function navbar-link-color($navbar-type, $color-type) {
-  @if $navbar-type == dark {
-    @return map-get($theme-site-navbar-dark-colors, $color-type);
-  }
-  @return map-get($theme-site-navbar-light-colors, $color-type);
 }
 
 @function get-navbar-breakpoints-for($target) {

--- a/packages/themes/default/styles/_functions.scss
+++ b/packages/themes/default/styles/_functions.scss
@@ -2,7 +2,7 @@
 
 @function map-deep-get($map, $keys...) {
   @each $key in $keys {
-      $map: map-get($map, $key);
+    $map: map-get($map, $key);
   }
   @return $map;
 }

--- a/packages/themes/default/styles/_functions.scss
+++ b/packages/themes/default/styles/_functions.scss
@@ -32,12 +32,12 @@
   $breakpoints: get-navbar-breakpoints-for($target-breakpoint);
 
   // Variable defaults.
-  $logo-height: $theme-site-navbar-logo-height;
-  $primary-font-size: $theme-site-navbar-primary-font-size * $theme-site-navbar-primary-line-height;
-  $primary-link-padding: $theme-site-navbar-primary-link-padding * 2;
+  $logo-height:           $theme-site-navbar-logo-height;
+  $primary-font-size:     $theme-site-navbar-primary-font-size * $theme-site-navbar-primary-line-height;
+  $primary-link-padding:  $theme-site-navbar-primary-link-padding * 2;
   // These are constant.
-  $brand-margin: $theme-site-navbar-brand-margin-y * 2;
-  $secondary-padding: $theme-site-navbar-secondary-padding-y * 2;
+  $brand-margin:          $theme-site-navbar-brand-margin-y * 2;
+  $secondary-padding:     $theme-site-navbar-secondary-padding-y * 2;
 
   @if length($breakpoints) == 0 {
     @return calc(#{$logo-height} + #{$primary-font-size} + #{$brand-margin} + #{$primary-link-padding} + #{$secondary-padding});
@@ -50,8 +50,8 @@
   }
   @if index($breakpoints, hide-primary) != null {
     // Orverride font size again with hidden height and set padding to none
-    $primary-font-size: $theme-site-navbar-primary-height-sm;
-    $primary-link-padding: 0;
+    $primary-font-size:     $theme-site-navbar-primary-height-sm;
+    $primary-link-padding:  0;
   }
   @return calc(#{$logo-height} + #{$primary-font-size} + #{$brand-margin} + #{$primary-link-padding} + #{$secondary-padding});
 }

--- a/packages/themes/default/styles/_mixins.scss
+++ b/packages/themes/default/styles/_mixins.scss
@@ -1,36 +1,36 @@
 @import "../../node_modules/bootstrap/scss/mixins";
 
 @mixin theme-apply-responsive-fonts(
-  $font-size: $font-size-sm,
+  $font-size:   $font-size-sm,
   $line-height: $line-height-base,
-  $breakpoint: $theme-responsive-text-breakpoint
+  $breakpoint:  $theme-responsive-text-breakpoint
 ) {
   @include media-breakpoint-down($breakpoint) {
-    font-size: $font-size;
-    line-height: $line-height;
+    font-size:    $font-size;
+    line-height:  $line-height;
   }
 }
 
 @mixin theme-apply-fonts(
-  $font-family: $font-family-sans-serif,
-  $font-size-sm: $font-size-sm,
-  $font-size: $font-size-base,
-  $font-weight: $font-weight-normal,
-  $letter-spacing: inherit,
-  $line-height-sm: $line-height-base,
-  $line-height: $line-height-base,
-  $sm-breakpoint: $theme-responsive-text-breakpoint
+  $font-family:     $font-family-sans-serif,
+  $font-size-sm:    $font-size-sm,
+  $font-size:       $font-size-base,
+  $font-weight:     $font-weight-normal,
+  $letter-spacing:  inherit,
+  $line-height-sm:  $line-height-base,
+  $line-height:     $line-height-base,
+  $sm-breakpoint:   $theme-responsive-text-breakpoint
 ) {
-  font-family: $font-family;
-  font-size: $font-size;
-  font-weight: $font-weight;
-  line-height: $line-height;
+  font-family:    $font-family;
+  font-size:      $font-size;
+  font-weight:    $font-weight;
+  line-height:    $line-height;
   letter-spacing: $letter-spacing;
 
   @include theme-apply-responsive-fonts(
-    $font-size: $font-size-sm,
+    $font-size:   $font-size-sm,
     $line-height: $line-height-sm,
-    $breakpoint: $sm-breakpoint
+    $breakpoint:  $sm-breakpoint
   );
 }
 
@@ -38,47 +38,47 @@
   @include border-radius($theme-card-border-radius);
   @include box-shadow($theme-card-box-shadow);
   background-color: $theme-card-background-color;
-  border: $theme-card-border;
+  border:           $theme-card-border;
 }
 
 @mixin theme-card-header() {
-  font-family: $theme-card-header-font-family;
-  font-size: $theme-card-header-font-size;
-  font-weight: $theme-card-header-font-weight;
-  color: $theme-card-header-color;
-  text-transform: $theme-card-header-text-transform;
-  letter-spacing: $theme-card-header-letter-spacing;
+  font-family:      $theme-card-header-font-family;
+  font-size:        $theme-card-header-font-size;
+  font-weight:      $theme-card-header-font-weight;
+  color:            $theme-card-header-color;
+  text-transform:   $theme-card-header-text-transform;
+  letter-spacing:   $theme-card-header-letter-spacing;
   background-color: $theme-card-header-background-color;
-  border-bottom: $theme-card-header-border;
+  border-bottom:    $theme-card-header-border;
 }
 
 @mixin theme-card-header-link() {
-  color: $theme-card-header-link-color;
-  text-decoration: $theme-card-header-link-decoration;
+  color:            $theme-card-header-link-color;
+  text-decoration:  $theme-card-header-link-decoration;
   &:hover {
-    color: $theme-card-header-link-hover-color;
-    text-decoration: $theme-card-header-link-hover-decoration;
+    color:            $theme-card-header-link-hover-color;
+    text-decoration:  $theme-card-header-link-hover-decoration;
   }
 }
 
 @mixin theme-content-body() {
   @include theme-apply-fonts(
-    $font-family: $theme-page-body-font-family,
-    $font-size-sm: $theme-page-body-font-size-sm,
-    $font-size: $theme-page-body-font-size,
-    $font-weight: $theme-page-body-font-weight,
-    $line-height-sm: $theme-page-body-line-height-sm,
-    $line-height: $theme-page-body-line-height,
+    $font-family:     $theme-page-body-font-family,
+    $font-size-sm:    $theme-page-body-font-size-sm,
+    $font-size:       $theme-page-body-font-size,
+    $font-weight:     $theme-page-body-font-weight,
+    $line-height-sm:  $theme-page-body-line-height-sm,
+    $line-height:     $theme-page-body-line-height,
   );
   color: $theme-page-body-color;
   h1 {
     @include theme-apply-fonts(
-      $font-family: $theme-content-heading-h1-font-family,
-      $font-size-sm: $theme-content-heading-h1-font-size-sm,
-      $font-size: $theme-content-heading-h1-font-size,
-      $font-weight: $theme-content-heading-h1-font-weight,
-      $line-height-sm: $theme-content-heading-h1-line-height-sm,
-      $line-height: $theme-content-heading-h1-line-height
+      $font-family:     $theme-content-heading-h1-font-family,
+      $font-size-sm:    $theme-content-heading-h1-font-size-sm,
+      $font-size:       $theme-content-heading-h1-font-size,
+      $font-weight:     $theme-content-heading-h1-font-weight,
+      $line-height-sm:  $theme-content-heading-h1-line-height-sm,
+      $line-height:     $theme-content-heading-h1-line-height
     );
     @include media-breakpoint-down($theme-responsive-text-breakpoint) {
       margin-bottom: $theme-content-heading-h1-margin-bottom-sm;
@@ -87,12 +87,12 @@
   }
   h2 {
     @include theme-apply-fonts(
-      $font-family: $theme-content-heading-h2-font-family,
-      $font-size-sm: $theme-content-heading-h2-font-size-sm,
-      $font-size: $theme-content-heading-h2-font-size,
-      $font-weight: $theme-content-heading-h2-font-weight,
-      $line-height-sm: $theme-content-heading-h2-line-height-sm,
-      $line-height: $theme-content-heading-h2-line-height
+      $font-family:     $theme-content-heading-h2-font-family,
+      $font-size-sm:    $theme-content-heading-h2-font-size-sm,
+      $font-size:       $theme-content-heading-h2-font-size,
+    $font-weight:       $theme-content-heading-h2-font-weight,
+      $line-height-sm:  $theme-content-heading-h2-line-height-sm,
+      $line-height:     $theme-content-heading-h2-line-height
     );
     @include media-breakpoint-down($theme-responsive-text-breakpoint) {
       margin-bottom: $theme-content-heading-h2-margin-bottom-sm;
@@ -101,12 +101,12 @@
   }
   h3 {
     @include theme-apply-fonts(
-      $font-family: $theme-content-heading-h3-font-family,
-      $font-size-sm: $theme-content-heading-h3-font-size-sm,
-      $font-size: $theme-content-heading-h3-font-size,
-      $font-weight: $theme-content-heading-h3-font-weight,
-      $line-height-sm: $theme-content-heading-h3-line-height-sm,
-      $line-height: $theme-content-heading-h3-line-height
+      $font-family:     $theme-content-heading-h3-font-family,
+      $font-size-sm:    $theme-content-heading-h3-font-size-sm,
+      $font-size:       $theme-content-heading-h3-font-size,
+      $font-weight:     $theme-content-heading-h3-font-weight,
+      $line-height-sm:  $theme-content-heading-h3-line-height-sm,
+      $line-height:     $theme-content-heading-h3-line-height
     );
     @include media-breakpoint-down($theme-responsive-text-breakpoint) {
       margin-bottom: $theme-content-heading-h3-margin-bottom-sm;
@@ -115,12 +115,12 @@
   }
   h4 {
     @include theme-apply-fonts(
-      $font-family: $theme-content-heading-h4-font-family,
-      $font-size-sm: $theme-content-heading-h4-font-size-sm,
-      $font-size: $theme-content-heading-h4-font-size,
-      $font-weight: $theme-content-heading-h4-font-weight,
-      $line-height-sm: $theme-content-heading-h4-line-height-sm,
-      $line-height: $theme-content-heading-h4-line-height
+      $font-family:     $theme-content-heading-h4-font-family,
+      $font-size-sm:    $theme-content-heading-h4-font-size-sm,
+      $font-size:       $theme-content-heading-h4-font-size,
+      $font-weight:     $theme-content-heading-h4-font-weight,
+      $line-height-sm:  $theme-content-heading-h4-line-height-sm,
+      $line-height:     $theme-content-heading-h4-line-height
     );
     @include media-breakpoint-down($theme-responsive-text-breakpoint) {
       margin-bottom: $theme-content-heading-h4-margin-bottom-sm;
@@ -129,12 +129,12 @@
   }
   h5 {
     @include theme-apply-fonts(
-      $font-family: $theme-content-heading-h5-font-family,
-      $font-size-sm: $theme-content-heading-h5-font-size-sm,
-      $font-size: $theme-content-heading-h5-font-size,
-      $font-weight: $theme-content-heading-h5-font-weight,
-      $line-height-sm: $theme-content-heading-h5-line-height-sm,
-      $line-height: $theme-content-heading-h5-line-height
+      $font-family:     $theme-content-heading-h5-font-family,
+      $font-size-sm:    $theme-content-heading-h5-font-size-sm,
+      $font-size:       $theme-content-heading-h5-font-size,
+      $font-weight:     $theme-content-heading-h5-font-weight,
+      $line-height-sm:  $theme-content-heading-h5-line-height-sm,
+      $line-height:     $theme-content-heading-h5-line-height
     );
     @include media-breakpoint-down($theme-responsive-text-breakpoint) {
       margin-bottom: $theme-content-heading-h5-margin-bottom-sm;
@@ -143,12 +143,12 @@
   }
   h6 {
     @include theme-apply-fonts(
-      $font-family: $theme-content-heading-h6-font-family,
-      $font-size-sm: $theme-content-heading-h6-font-size-sm,
-      $font-size: $theme-content-heading-h6-font-size,
-      $font-weight: $theme-content-heading-h6-font-weight,
-      $line-height-sm: $theme-content-heading-h6-line-height-sm,
-      $line-height: $theme-content-heading-h6-line-height
+      $font-family:     $theme-content-heading-h6-font-family,
+      $font-size-sm:    $theme-content-heading-h6-font-size-sm,
+      $font-size:       $theme-content-heading-h6-font-size,
+      $font-weight:     $theme-content-heading-h6-font-weight,
+      $line-height-sm:  $theme-content-heading-h6-line-height-sm,
+      $line-height:     $theme-content-heading-h6-line-height
     );
     @include media-breakpoint-down($theme-responsive-text-breakpoint) {
       margin-bottom: $theme-content-heading-h6-margin-bottom-sm;
@@ -188,14 +188,14 @@
 
 @mixin theme-embed-responsive($ratio-x, $ratio-y) {
   position: relative;
-  display: block;
-  width: 100%;
-  padding: 0;
+  display:  block;
+  width:    100%;
+  padding:  0;
   overflow: hidden;
 
   &::before {
-    display: block;
-    content: "";
+    display:  block;
+    content:  "";
     @if $ratio-y and $ratio-x {
       padding-top: percentage($ratio-y / $ratio-x);
     }
@@ -204,19 +204,19 @@
 
 @mixin theme-embed-responsive-item() {
   position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border: 0;
+  top:      0;
+  bottom:   0;
+  left:     0;
+  width:    100%;
+  height:   100%;
+  border:   0;
 }
 
 @mixin theme-hide-scrollbars() {
-  scrollbar-width: none;
+  scrollbar-width:    none;
   -ms-overflow-style: none;
   &::-webkit-scrollbar {
-    width: 0;
+    width:  0;
     height: 0;
   }
 }
@@ -226,14 +226,14 @@
   $font-size-sm,
   $line-height,
   $line-height-sm,
-  $num: 2,
+  $num:           2,
   $text-overflow: ellipsis,
-  $breakpoint: $theme-responsive-text-max-lines-breakpoint,
+  $breakpoint:    $theme-responsive-text-max-lines-breakpoint,
 ) {
-  display: block;
-  max-height: ($font-size * $line-height) * $num;
-  overflow: hidden;
-  text-overflow: $text-overflow;
+  display:        block;
+  max-height:     ($font-size * $line-height) * $num;
+  overflow:       hidden;
+  text-overflow:  $text-overflow;
   @include media-breakpoint-down($breakpoint) {
     max-height: ($font-size-sm * $line-height-sm) * $num;
   }
@@ -241,38 +241,38 @@
 
 @mixin theme-media-caption() {
   @include theme-media-common-footer();
-  font-size: $theme-media-caption-font-size;
-  font-weight: $theme-media-caption-font-weight;
-  line-height: $theme-media-caption-line-height;
-  color: $theme-media-caption-color;
+  font-size:    $theme-media-caption-font-size;
+  font-weight:  $theme-media-caption-font-weight;
+  line-height:  $theme-media-caption-line-height;
+  color:        $theme-media-caption-color;
 }
 
 @mixin theme-media-credit() {
   @include theme-media-common-footer();
-  font-size: $theme-media-credit-font-size;
-  font-style: $theme-media-credit-font-style;
-  font-weight: $theme-media-credit-font-weight;
-  line-height: $theme-media-credit-line-height;
-  color: $theme-media-credit-color;
+  font-size:    $theme-media-credit-font-size;
+  font-style:   $theme-media-credit-font-style;
+  font-weight:  $theme-media-credit-font-weight;
+  line-height:  $theme-media-credit-line-height;
+  color:        $theme-media-credit-color;
 }
 
 @mixin theme-media-common-footer() {
-  display: block;
-  padding: $theme-media-footer-padding-y $theme-media-footer-padding-x;
-  margin: 0;
-  font-family: $theme-media-footer-font-family;
-  font-size: $theme-media-footer-font-size;
-  line-height: $theme-media-footer-line-height;
-  text-align: left;
+  display:        block;
+  padding:        $theme-media-footer-padding-y $theme-media-footer-padding-x;
+  margin:         0;
+  font-family:    $theme-media-footer-font-family;
+  font-size:      $theme-media-footer-font-size;
+  line-height:    $theme-media-footer-line-height;
+  text-align:     left;
   letter-spacing: normal;
 }
 
 @mixin theme-navbar() {
-  position: relative;
-  display: flex;
-  flex-flow: row nowrap;
-  align-items: center;
-  justify-content: flex-start;
+  position:         relative;
+  display:          flex;
+  flex-flow:        row nowrap;
+  align-items:      center;
+  justify-content:  flex-start;
 }
 
 @mixin theme-navbar-link-background-color($background-color-map) {
@@ -285,10 +285,10 @@
   }
 }
 
-@mixin theme-navbar-link-color($map, $theme) {
-  $color: map-deep-get($map, $theme, default);
-  $hover: map-deep-get($map, $theme, hover);
-  $active: map-deep-get($map, $theme, active);
+@mixin theme-navbar-link-color($map, $navbar-type) {
+  $color:   map-deep-get($map, $navbar-type, default);
+  $hover:   map-deep-get($map, $navbar-type, hover);
+  $active:  map-deep-get($map, $navbar-type, active);
 
   color: $color;
   svg {
@@ -319,30 +319,30 @@
 }
 
 @mixin theme-page-body-spacing() {
-  padding-right: $theme-page-body-padding;
-  padding-left: $theme-page-body-padding;
-  margin-bottom: $theme-page-body-margin-bottom;
+  padding-right:  $theme-page-body-padding;
+  padding-left:   $theme-page-body-padding;
+  margin-bottom:  $theme-page-body-margin-bottom;
   @include media-breakpoint-down($theme-responsive-text-breakpoint) {
-    padding-right: $theme-page-body-padding-sm;
-    padding-left: $theme-page-body-padding-sm;
-    margin-bottom: $theme-page-body-margin-bottom-sm;
+    padding-right:  $theme-page-body-padding-sm;
+    padding-left:   $theme-page-body-padding-sm;
+    margin-bottom:  $theme-page-body-margin-bottom-sm;
   }
 }
 
 @mixin theme-page-header-spacing() {
   padding: $theme-page-header-padding;
   @include media-breakpoint-down($theme-responsive-text-breakpoint) {
-    padding-top: $theme-page-header-padding-sm;
-    padding-right: $theme-page-header-padding-sm;
-    padding-left: $theme-page-header-padding-sm;
+    padding-top:    $theme-page-header-padding-sm;
+    padding-right:  $theme-page-header-padding-sm;
+    padding-left:   $theme-page-header-padding-sm;
   }
 }
 
 @mixin theme-toggle-button() {
-  cursor: pointer;
+  cursor:           pointer;
   background-color: transparent;
-  border-color: transparent;
-  border-style: none;
+  border-color:     transparent;
+  border-style:     none;
   &:focus {
     outline: none;
   }

--- a/packages/themes/default/styles/_mixins.scss
+++ b/packages/themes/default/styles/_mixins.scss
@@ -285,10 +285,10 @@
   }
 }
 
-@mixin theme-navbar-link-color($color-map) {
-  $color: map-get($color-map, default);
-  $hover: map-get($color-map, hover);
-  $active: map-get($color-map, active);
+@mixin theme-navbar-link-color($map, $theme) {
+  $color: map-deep-get($map, $theme, default);
+  $hover: map-deep-get($map, $theme, hover);
+  $active: map-deep-get($map, $theme, active);
 
   color: $color;
   svg {

--- a/packages/themes/default/styles/_mixins.scss
+++ b/packages/themes/default/styles/_mixins.scss
@@ -1,36 +1,36 @@
 @import "../../node_modules/bootstrap/scss/mixins";
 
 @mixin theme-apply-responsive-fonts(
-  $font-size:   $font-size-sm,
+  $font-size: $font-size-sm,
   $line-height: $line-height-base,
-  $breakpoint:  $theme-responsive-text-breakpoint
+  $breakpoint: $theme-responsive-text-breakpoint
 ) {
   @include media-breakpoint-down($breakpoint) {
-    font-size:    $font-size;
-    line-height:  $line-height;
+    font-size: $font-size;
+    line-height: $line-height;
   }
 }
 
 @mixin theme-apply-fonts(
-  $font-family:     $font-family-sans-serif,
-  $font-size-sm:    $font-size-sm,
-  $font-size:       $font-size-base,
-  $font-weight:     $font-weight-normal,
-  $letter-spacing:  inherit,
-  $line-height-sm:  $line-height-base,
-  $line-height:     $line-height-base,
-  $sm-breakpoint:   $theme-responsive-text-breakpoint
+  $font-family: $font-family-sans-serif,
+  $font-size-sm: $font-size-sm,
+  $font-size: $font-size-base,
+  $font-weight: $font-weight-normal,
+  $letter-spacing: inherit,
+  $line-height-sm: $line-height-base,
+  $line-height: $line-height-base,
+  $sm-breakpoint: $theme-responsive-text-breakpoint
 ) {
-  font-family:    $font-family;
-  font-size:      $font-size;
-  font-weight:    $font-weight;
-  line-height:    $line-height;
+  font-family: $font-family;
+  font-size: $font-size;
+  font-weight: $font-weight;
+  line-height: $line-height;
   letter-spacing: $letter-spacing;
 
   @include theme-apply-responsive-fonts(
-    $font-size:   $font-size-sm,
+    $font-size: $font-size-sm,
     $line-height: $line-height-sm,
-    $breakpoint:  $sm-breakpoint
+    $breakpoint: $sm-breakpoint
   );
 }
 
@@ -38,47 +38,47 @@
   @include border-radius($theme-card-border-radius);
   @include box-shadow($theme-card-box-shadow);
   background-color: $theme-card-background-color;
-  border:           $theme-card-border;
+  border: $theme-card-border;
 }
 
 @mixin theme-card-header() {
-  font-family:      $theme-card-header-font-family;
-  font-size:        $theme-card-header-font-size;
-  font-weight:      $theme-card-header-font-weight;
-  color:            $theme-card-header-color;
-  text-transform:   $theme-card-header-text-transform;
-  letter-spacing:   $theme-card-header-letter-spacing;
+  font-family: $theme-card-header-font-family;
+  font-size: $theme-card-header-font-size;
+  font-weight: $theme-card-header-font-weight;
+  color: $theme-card-header-color;
+  text-transform: $theme-card-header-text-transform;
+  letter-spacing: $theme-card-header-letter-spacing;
   background-color: $theme-card-header-background-color;
-  border-bottom:    $theme-card-header-border;
+  border-bottom: $theme-card-header-border;
 }
 
 @mixin theme-card-header-link() {
-  color:            $theme-card-header-link-color;
-  text-decoration:  $theme-card-header-link-decoration;
+  color: $theme-card-header-link-color;
+  text-decoration: $theme-card-header-link-decoration;
   &:hover {
-    color:            $theme-card-header-link-hover-color;
-    text-decoration:  $theme-card-header-link-hover-decoration;
+    color: $theme-card-header-link-hover-color;
+    text-decoration: $theme-card-header-link-hover-decoration;
   }
 }
 
 @mixin theme-content-body() {
   @include theme-apply-fonts(
-    $font-family:     $theme-page-body-font-family,
-    $font-size-sm:    $theme-page-body-font-size-sm,
-    $font-size:       $theme-page-body-font-size,
-    $font-weight:     $theme-page-body-font-weight,
-    $line-height-sm:  $theme-page-body-line-height-sm,
-    $line-height:     $theme-page-body-line-height,
+    $font-family: $theme-page-body-font-family,
+    $font-size-sm: $theme-page-body-font-size-sm,
+    $font-size: $theme-page-body-font-size,
+    $font-weight: $theme-page-body-font-weight,
+    $line-height-sm: $theme-page-body-line-height-sm,
+    $line-height: $theme-page-body-line-height,
   );
   color: $theme-page-body-color;
   h1 {
     @include theme-apply-fonts(
-      $font-family:     $theme-content-heading-h1-font-family,
-      $font-size-sm:    $theme-content-heading-h1-font-size-sm,
-      $font-size:       $theme-content-heading-h1-font-size,
-      $font-weight:     $theme-content-heading-h1-font-weight,
-      $line-height-sm:  $theme-content-heading-h1-line-height-sm,
-      $line-height:     $theme-content-heading-h1-line-height
+      $font-family: $theme-content-heading-h1-font-family,
+      $font-size-sm: $theme-content-heading-h1-font-size-sm,
+      $font-size: $theme-content-heading-h1-font-size,
+      $font-weight: $theme-content-heading-h1-font-weight,
+      $line-height-sm: $theme-content-heading-h1-line-height-sm,
+      $line-height: $theme-content-heading-h1-line-height
     );
     @include media-breakpoint-down($theme-responsive-text-breakpoint) {
       margin-bottom: $theme-content-heading-h1-margin-bottom-sm;
@@ -87,12 +87,12 @@
   }
   h2 {
     @include theme-apply-fonts(
-      $font-family:     $theme-content-heading-h2-font-family,
-      $font-size-sm:    $theme-content-heading-h2-font-size-sm,
-      $font-size:       $theme-content-heading-h2-font-size,
-    $font-weight:       $theme-content-heading-h2-font-weight,
-      $line-height-sm:  $theme-content-heading-h2-line-height-sm,
-      $line-height:     $theme-content-heading-h2-line-height
+      $font-family: $theme-content-heading-h2-font-family,
+      $font-size-sm: $theme-content-heading-h2-font-size-sm,
+      $font-size: $theme-content-heading-h2-font-size,
+      $font-weight: $theme-content-heading-h2-font-weight,
+      $line-height-sm: $theme-content-heading-h2-line-height-sm,
+      $line-height: $theme-content-heading-h2-line-height
     );
     @include media-breakpoint-down($theme-responsive-text-breakpoint) {
       margin-bottom: $theme-content-heading-h2-margin-bottom-sm;
@@ -101,12 +101,12 @@
   }
   h3 {
     @include theme-apply-fonts(
-      $font-family:     $theme-content-heading-h3-font-family,
-      $font-size-sm:    $theme-content-heading-h3-font-size-sm,
-      $font-size:       $theme-content-heading-h3-font-size,
-      $font-weight:     $theme-content-heading-h3-font-weight,
-      $line-height-sm:  $theme-content-heading-h3-line-height-sm,
-      $line-height:     $theme-content-heading-h3-line-height
+      $font-family: $theme-content-heading-h3-font-family,
+      $font-size-sm: $theme-content-heading-h3-font-size-sm,
+      $font-size: $theme-content-heading-h3-font-size,
+      $font-weight: $theme-content-heading-h3-font-weight,
+      $line-height-sm: $theme-content-heading-h3-line-height-sm,
+      $line-height: $theme-content-heading-h3-line-height
     );
     @include media-breakpoint-down($theme-responsive-text-breakpoint) {
       margin-bottom: $theme-content-heading-h3-margin-bottom-sm;
@@ -115,12 +115,12 @@
   }
   h4 {
     @include theme-apply-fonts(
-      $font-family:     $theme-content-heading-h4-font-family,
-      $font-size-sm:    $theme-content-heading-h4-font-size-sm,
-      $font-size:       $theme-content-heading-h4-font-size,
-      $font-weight:     $theme-content-heading-h4-font-weight,
-      $line-height-sm:  $theme-content-heading-h4-line-height-sm,
-      $line-height:     $theme-content-heading-h4-line-height
+      $font-family: $theme-content-heading-h4-font-family,
+      $font-size-sm: $theme-content-heading-h4-font-size-sm,
+      $font-size: $theme-content-heading-h4-font-size,
+      $font-weight: $theme-content-heading-h4-font-weight,
+      $line-height-sm: $theme-content-heading-h4-line-height-sm,
+      $line-height: $theme-content-heading-h4-line-height
     );
     @include media-breakpoint-down($theme-responsive-text-breakpoint) {
       margin-bottom: $theme-content-heading-h4-margin-bottom-sm;
@@ -129,12 +129,12 @@
   }
   h5 {
     @include theme-apply-fonts(
-      $font-family:     $theme-content-heading-h5-font-family,
-      $font-size-sm:    $theme-content-heading-h5-font-size-sm,
-      $font-size:       $theme-content-heading-h5-font-size,
-      $font-weight:     $theme-content-heading-h5-font-weight,
-      $line-height-sm:  $theme-content-heading-h5-line-height-sm,
-      $line-height:     $theme-content-heading-h5-line-height
+      $font-family: $theme-content-heading-h5-font-family,
+      $font-size-sm: $theme-content-heading-h5-font-size-sm,
+      $font-size: $theme-content-heading-h5-font-size,
+      $font-weight: $theme-content-heading-h5-font-weight,
+      $line-height-sm: $theme-content-heading-h5-line-height-sm,
+      $line-height: $theme-content-heading-h5-line-height
     );
     @include media-breakpoint-down($theme-responsive-text-breakpoint) {
       margin-bottom: $theme-content-heading-h5-margin-bottom-sm;
@@ -143,12 +143,12 @@
   }
   h6 {
     @include theme-apply-fonts(
-      $font-family:     $theme-content-heading-h6-font-family,
-      $font-size-sm:    $theme-content-heading-h6-font-size-sm,
-      $font-size:       $theme-content-heading-h6-font-size,
-      $font-weight:     $theme-content-heading-h6-font-weight,
-      $line-height-sm:  $theme-content-heading-h6-line-height-sm,
-      $line-height:     $theme-content-heading-h6-line-height
+      $font-family: $theme-content-heading-h6-font-family,
+      $font-size-sm: $theme-content-heading-h6-font-size-sm,
+      $font-size: $theme-content-heading-h6-font-size,
+      $font-weight: $theme-content-heading-h6-font-weight,
+      $line-height-sm: $theme-content-heading-h6-line-height-sm,
+      $line-height: $theme-content-heading-h6-line-height
     );
     @include media-breakpoint-down($theme-responsive-text-breakpoint) {
       margin-bottom: $theme-content-heading-h6-margin-bottom-sm;
@@ -188,14 +188,14 @@
 
 @mixin theme-embed-responsive($ratio-x, $ratio-y) {
   position: relative;
-  display:  block;
-  width:    100%;
-  padding:  0;
+  display: block;
+  width: 100%;
+  padding: 0;
   overflow: hidden;
 
   &::before {
-    display:  block;
-    content:  "";
+    display: block;
+    content: "";
     @if $ratio-y and $ratio-x {
       padding-top: percentage($ratio-y / $ratio-x);
     }
@@ -204,19 +204,19 @@
 
 @mixin theme-embed-responsive-item() {
   position: absolute;
-  top:      0;
-  bottom:   0;
-  left:     0;
-  width:    100%;
-  height:   100%;
-  border:   0;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
 }
 
 @mixin theme-hide-scrollbars() {
-  scrollbar-width:    none;
+  scrollbar-width: none;
   -ms-overflow-style: none;
   &::-webkit-scrollbar {
-    width:  0;
+    width: 0;
     height: 0;
   }
 }
@@ -226,14 +226,14 @@
   $font-size-sm,
   $line-height,
   $line-height-sm,
-  $num:           2,
+  $num: 2,
   $text-overflow: ellipsis,
-  $breakpoint:    $theme-responsive-text-max-lines-breakpoint,
+  $breakpoint: $theme-responsive-text-max-lines-breakpoint,
 ) {
-  display:        block;
-  max-height:     ($font-size * $line-height) * $num;
-  overflow:       hidden;
-  text-overflow:  $text-overflow;
+  display: block;
+  max-height: ($font-size * $line-height) * $num;
+  overflow: hidden;
+  text-overflow: $text-overflow;
   @include media-breakpoint-down($breakpoint) {
     max-height: ($font-size-sm * $line-height-sm) * $num;
   }
@@ -241,38 +241,38 @@
 
 @mixin theme-media-caption() {
   @include theme-media-common-footer();
-  font-size:    $theme-media-caption-font-size;
-  font-weight:  $theme-media-caption-font-weight;
-  line-height:  $theme-media-caption-line-height;
-  color:        $theme-media-caption-color;
+  font-size: $theme-media-caption-font-size;
+  font-weight: $theme-media-caption-font-weight;
+  line-height: $theme-media-caption-line-height;
+  color: $theme-media-caption-color;
 }
 
 @mixin theme-media-credit() {
   @include theme-media-common-footer();
-  font-size:    $theme-media-credit-font-size;
-  font-style:   $theme-media-credit-font-style;
-  font-weight:  $theme-media-credit-font-weight;
-  line-height:  $theme-media-credit-line-height;
-  color:        $theme-media-credit-color;
+  font-size: $theme-media-credit-font-size;
+  font-style: $theme-media-credit-font-style;
+  font-weight: $theme-media-credit-font-weight;
+  line-height: $theme-media-credit-line-height;
+  color: $theme-media-credit-color;
 }
 
 @mixin theme-media-common-footer() {
-  display:        block;
-  padding:        $theme-media-footer-padding-y $theme-media-footer-padding-x;
-  margin:         0;
-  font-family:    $theme-media-footer-font-family;
-  font-size:      $theme-media-footer-font-size;
-  line-height:    $theme-media-footer-line-height;
-  text-align:     left;
+  display: block;
+  padding: $theme-media-footer-padding-y $theme-media-footer-padding-x;
+  margin: 0;
+  font-family: $theme-media-footer-font-family;
+  font-size: $theme-media-footer-font-size;
+  line-height: $theme-media-footer-line-height;
+  text-align: left;
   letter-spacing: normal;
 }
 
 @mixin theme-navbar() {
-  position:         relative;
-  display:          flex;
-  flex-flow:        row nowrap;
-  align-items:      center;
-  justify-content:  flex-start;
+  position: relative;
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  justify-content: flex-start;
 }
 
 @mixin theme-navbar-link-background-color($background-color-map) {
@@ -286,9 +286,9 @@
 }
 
 @mixin theme-navbar-link-color($map, $navbar-type) {
-  $color:   map-deep-get($map, $navbar-type, default);
-  $hover:   map-deep-get($map, $navbar-type, hover);
-  $active:  map-deep-get($map, $navbar-type, active);
+  $color: map-deep-get($map, $navbar-type, default);
+  $hover: map-deep-get($map, $navbar-type, hover);
+  $active: map-deep-get($map, $navbar-type, active);
 
   color: $color;
   svg {
@@ -319,30 +319,30 @@
 }
 
 @mixin theme-page-body-spacing() {
-  padding-right:  $theme-page-body-padding;
-  padding-left:   $theme-page-body-padding;
-  margin-bottom:  $theme-page-body-margin-bottom;
+  padding-right: $theme-page-body-padding;
+  padding-left: $theme-page-body-padding;
+  margin-bottom: $theme-page-body-margin-bottom;
   @include media-breakpoint-down($theme-responsive-text-breakpoint) {
-    padding-right:  $theme-page-body-padding-sm;
-    padding-left:   $theme-page-body-padding-sm;
-    margin-bottom:  $theme-page-body-margin-bottom-sm;
+    padding-right: $theme-page-body-padding-sm;
+    padding-left: $theme-page-body-padding-sm;
+    margin-bottom: $theme-page-body-margin-bottom-sm;
   }
 }
 
 @mixin theme-page-header-spacing() {
   padding: $theme-page-header-padding;
   @include media-breakpoint-down($theme-responsive-text-breakpoint) {
-    padding-top:    $theme-page-header-padding-sm;
-    padding-right:  $theme-page-header-padding-sm;
-    padding-left:   $theme-page-header-padding-sm;
+    padding-top: $theme-page-header-padding-sm;
+    padding-right: $theme-page-header-padding-sm;
+    padding-left: $theme-page-header-padding-sm;
   }
 }
 
 @mixin theme-toggle-button() {
-  cursor:           pointer;
+  cursor: pointer;
   background-color: transparent;
-  border-color:     transparent;
-  border-style:     none;
+  border-color: transparent;
+  border-style: none;
   &:focus {
     outline: none;
   }

--- a/packages/themes/default/styles/_variables.scss
+++ b/packages/themes/default/styles/_variables.scss
@@ -1,10 +1,9 @@
 // Fonts
-$theme-font-family-sans-serif: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
-$theme-font-family-serif: "Georgia", "Cambria", "Times New Roman", "Times", serif !default;
-$theme-font-family-page-title: $theme-font-family-serif !default;
-
+$theme-font-family-sans-serif:  -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
+$theme-font-family-serif:       "Georgia", "Cambria", "Times New Roman", "Times", serif !default;
+$theme-font-family-page-title:  $theme-font-family-serif !default;
 // Set default Bootstrap font to theme font.
-$font-family-sans-serif: $theme-font-family-sans-serif !default;
+$font-family-sans-serif:        $theme-font-family-sans-serif !default;
 
 $black:           #000 !default;
 $body-color:      $black !default;
@@ -552,7 +551,7 @@ $theme-site-header-font-family: $theme-font-family-sans-serif !default;
 $theme-site-header-opacity:     .98 !default;
 $theme-site-header-z-index:     5000000 !default;
 
-//Navbar
+// Navbar
 @import "variables/navbar";
 
 // Site Footer

--- a/packages/themes/default/styles/_variables.scss
+++ b/packages/themes/default/styles/_variables.scss
@@ -533,7 +533,7 @@ $theme-ad-sticky-leaderboard-close-color:       $white !default;
 $theme-ad-sticky-leaderboard-close-position:    .25rem !default;
 $theme-ad-sticky-leaderboard-close-size:        1.25rem !default;
 
-// Navbar / Header
+// Header
 $theme-site-header-breakpoints: () !default;
 $theme-site-header-breakpoints: map-merge(
   (
@@ -552,133 +552,8 @@ $theme-site-header-font-family: $theme-font-family-sans-serif !default;
 $theme-site-header-opacity:     .98 !default;
 $theme-site-header-z-index:     5000000 !default;
 
-$theme-site-navbar-dark-color:          rgba($white, .75) !default;
-$theme-site-navbar-dark-hover-color:    $white !default;
-$theme-site-navbar-dark-active-color:   $theme-site-navbar-dark-hover-color !default;
-$theme-site-navbar-light-color:         rgba($black, .75) !default;
-$theme-site-navbar-light-hover-color:   $black !default;
-$theme-site-navbar-light-active-color:  $theme-site-navbar-light-hover-color !default;
-$theme-site-navbar-padding-x:           16px !default;
-$theme-site-navbar-padding-y:           0 !default;
-
-$theme-site-navbar-dark-colors: (
-  default: $theme-site-navbar-dark-color,
-  hover: $theme-site-navbar-dark-hover-color,
-  active: $theme-site-navbar-dark-active-color
-);
-
-$theme-site-navbar-light-colors: (
-  default: $theme-site-navbar-light-color,
-  hover: $theme-site-navbar-light-hover-color,
-  active: $theme-site-navbar-light-active-color
-);
-
-$theme-site-navbar-brand-margin-y: 0 !default;
-$theme-site-navbar-brand-margin-x: 12px !default;
-
-$theme-site-navbar-primary-bg-color:        $primary !default;
-$theme-site-navbar-primary-font-family:     $theme-site-header-font-family !default;
-$theme-site-navbar-primary-font-size:       16px !default;
-$theme-site-navbar-primary-font-size-sm:    $theme-site-navbar-primary-font-size - 2 !default;
-$theme-site-navbar-primary-font-weight:     $font-weight-normal !default;
-$theme-site-navbar-primary-height-sm:       4px !default;
-$theme-site-navbar-primary-line-height:     get-line-height($theme-site-navbar-primary-font-size, 24px) !default;
-$theme-site-navbar-primary-line-height-sm:  get-line-height($theme-site-navbar-primary-font-size-sm, 21px) !default;
-$theme-site-navbar-primary-padding-x:       16px !default;
-$theme-site-navbar-primary-padding-y:       0 !default;
-$theme-site-navbar-primary-type:            dark !default;
-
-$theme-site-navbar-primary-link-active-background-color:  initial !default;
-$theme-site-navbar-primary-link-active-color:             navbar-link-color($theme-site-navbar-primary-type, active) !default;
-$theme-site-navbar-primary-link-active-decoration:        underline !default;
-$theme-site-navbar-primary-link-background-color:         initial !default;
-$theme-site-navbar-primary-link-color:                    navbar-link-color($theme-site-navbar-primary-type, default) !default;
-$theme-site-navbar-primary-link-decoration:               none !default;
-$theme-site-navbar-primary-link-hover-background-color:   initial !default;
-$theme-site-navbar-primary-link-hover-color:              navbar-link-color($theme-site-navbar-primary-type, hover) !default;
-$theme-site-navbar-primary-link-hover-decoration:         underline !default;
-$theme-site-navbar-primary-link-padding:                  8px !default;
-
-$theme-site-navbar-primary-colors: (
-  default: $theme-site-navbar-primary-link-color,
-  hover: $theme-site-navbar-primary-link-hover-color,
-  active: $theme-site-navbar-primary-link-active-color
-);
-
-$theme-site-navbar-primary-decorations: (
-  default: $theme-site-navbar-primary-link-decoration,
-  hover: $theme-site-navbar-primary-link-hover-decoration,
-  active: $theme-site-navbar-primary-link-active-decoration
-);
-
-$theme-site-navbar-primary-background-colors: (
-  default: $theme-site-navbar-primary-link-background-color,
-  hover: $theme-site-navbar-primary-link-hover-background-color,
-  active: $theme-site-navbar-primary-link-active-background-color
-);
-
-$theme-site-navbar-secondary-bg-color:        $dark !default;
-$theme-site-navbar-secondary-font-family:     $theme-site-header-font-family !default;
-$theme-site-navbar-secondary-font-size:       14px !default;
-$theme-site-navbar-secondary-font-size-sm:    $theme-site-navbar-secondary-font-size - 2 !default;
-$theme-site-navbar-secondary-font-weight:     $font-weight-normal !default;
-$theme-site-navbar-secondary-line-height:     get-line-height($theme-site-navbar-secondary-font-size, 21px) !default;
-$theme-site-navbar-secondary-line-height-sm:  get-line-height($theme-site-navbar-secondary-font-size-sm, 18px) !default;
-$theme-site-navbar-secondary-padding-x:       16px !default;
-$theme-site-navbar-secondary-padding-y:       10px !default;
-$theme-site-navbar-secondary-type:            dark !default;
-
-$theme-site-navbar-secondary-link-active-background-color:  initial !default;
-$theme-site-navbar-secondary-link-active-color:             navbar-link-color($theme-site-navbar-secondary-type, active) !default;
-$theme-site-navbar-secondary-link-active-decoration:        underline !default;
-$theme-site-navbar-secondary-link-background-color:         initial !default;
-$theme-site-navbar-secondary-link-color:                    navbar-link-color($theme-site-navbar-secondary-type, default) !default;
-$theme-site-navbar-secondary-link-decoration:               none !default;
-$theme-site-navbar-secondary-link-hover-background-color:   initial !default;
-$theme-site-navbar-secondary-link-hover-color:              navbar-link-color($theme-site-navbar-secondary-type, hover) !default;
-$theme-site-navbar-secondary-link-hover-decoration:         underline !default;
-$theme-site-navbar-secondary-link-padding:                  8px !default;
-
-$theme-site-navbar-secondary-colors: (
-  default: $theme-site-navbar-secondary-link-color,
-  hover: $theme-site-navbar-secondary-link-hover-color,
-  active: $theme-site-navbar-secondary-link-active-color
-);
-
-$theme-site-navbar-secondary-decorations: (
-  default: $theme-site-navbar-secondary-link-decoration,
-  hover: $theme-site-navbar-secondary-link-hover-decoration,
-  active: $theme-site-navbar-secondary-link-active-decoration
-);
-
-$theme-site-navbar-secondary-background-colors: (
-  default: $theme-site-navbar-secondary-link-background-color,
-  hover: $theme-site-navbar-secondary-link-hover-background-color,
-  active: $theme-site-navbar-secondary-link-active-background-color
-);
-
-$theme-site-navbar-tertiary-link-active-color:             navbar-link-color($theme-site-navbar-secondary-type, active) !default;
-$theme-site-navbar-tertiary-link-color:                    navbar-link-color($theme-site-navbar-secondary-type, default) !default;
-$theme-site-navbar-tertiary-link-hover-color:              navbar-link-color($theme-site-navbar-secondary-type, hover) !default;
-
-$theme-site-navbar-tertiary-colors: (
-  default: $theme-site-navbar-tertiary-link-color,
-  hover: $theme-site-navbar-tertiary-link-hover-color,
-  active: $theme-site-navbar-tertiary-link-active-color
-);
-
-$theme-site-navbar-link-transition: color ease 300ms, text-decoration ease 300ms, background-color ease 300ms !default;
-
-$theme-site-navbar-logo-drop-shadow:   1px 1px 1px rgba(0, 0, 0, .35) !default;
-$theme-site-navbar-logo-height:        60px !default;
-$theme-site-navbar-logo-height-sm:     $theme-site-navbar-logo-height / 2 !default;
-
-$theme-site-navbar-icon-transition:  fill ease 300ms !default;
-
-$theme-site-navbar-menu-box-shadow:             0 8px 17px 0 rgba(0, 0, 0, .2), 0 6px 20px 0 rgba(0, 0, 0, .19) !default;
-$theme-site-navbar-menu-width:                  264px !default;
-$theme-site-navbar-menu-max-width:              75vw !default;
-$theme-site-navbar-menu-hover-background-color: lighten($theme-site-navbar-primary-bg-color, 60%) !default;
+//Navbar
+@import "variables/navbar";
 
 // Site Footer
 $theme-site-footer-box-shadow:  $theme-box-shadow-lg !default;

--- a/packages/themes/default/styles/theme/_navbar.scss
+++ b/packages/themes/default/styles/theme/_navbar.scss
@@ -55,7 +55,7 @@
   margin-bottom: auto;
 
   & > .icon {
-    @include theme-navbar-link-color($theme-site-navbar-secondary-colors);
+    @include theme-navbar-link-color($theme-site-navbar-map, dark);
   }
 }
 
@@ -120,7 +120,7 @@
       }
 
       &__link {
-        @include theme-navbar-link-color($theme-site-navbar-primary-colors);
+        @include theme-navbar-link-color($theme-site-navbar-map, dark);
         @include theme-navbar-link-decoration($theme-site-navbar-primary-decorations);
       }
     }
@@ -152,7 +152,7 @@
         }
       }
       &__link {
-        @include theme-navbar-link-color($theme-site-navbar-secondary-colors);
+        @include theme-navbar-link-color($theme-site-navbar-map, dark);
         @include theme-navbar-link-decoration($theme-site-navbar-secondary-decorations);
         padding: $theme-site-navbar-secondary-link-padding;
         padding-bottom: 0;
@@ -188,7 +188,7 @@
         }
       }
       &__link {
-        @include theme-navbar-link-color($theme-site-navbar-tertiary-colors);
+        @include theme-navbar-link-color($theme-site-navbar-map, dark);
         @include theme-navbar-link-decoration($theme-site-navbar-secondary-decorations);
         padding: $theme-site-navbar-secondary-link-padding;
         padding-top: 0;

--- a/packages/themes/default/styles/variables/_navbar.scss
+++ b/packages/themes/default/styles/variables/_navbar.scss
@@ -1,10 +1,10 @@
 /* Navbar */
 
 //  Spacing
-$theme-site-navbar-padding-x:           16px !default;
-$theme-site-navbar-padding-y:           0 !default;
-$theme-site-navbar-brand-margin-y: 0 !default;
-$theme-site-navbar-brand-margin-x: 12px !default;
+$theme-site-navbar-padding-x:       16px !default;
+$theme-site-navbar-padding-y:       0 !default;
+$theme-site-navbar-brand-margin-y:  0 !default;
+$theme-site-navbar-brand-margin-x:  12px !default;
 
 // Colors
 
@@ -21,14 +21,14 @@ $theme-site-navbar-light-active-color:  $theme-site-navbar-light-hover-color !de
 // Themes
 $theme-site-navbar-map: (
   dark: (
-    default: $theme-site-navbar-dark-color,
-    hover: $theme-site-navbar-dark-hover-color,
-    active: $theme-site-navbar-dark-active-color
+    default:  $theme-site-navbar-dark-color,
+    hover:    $theme-site-navbar-dark-hover-color,
+    active:   $theme-site-navbar-dark-active-color
   ),
   light: (
-    default: $theme-site-navbar-light-color,
-    hover: $theme-site-navbar-light-hover-color,
-    active: $theme-site-navbar-light-active-color
+    default:  $theme-site-navbar-light-color,
+    hover:    $theme-site-navbar-light-hover-color,
+    active:   $theme-site-navbar-light-active-color
   )
 );
 
@@ -56,15 +56,15 @@ $theme-site-navbar-primary-link-hover-decoration:         underline !default;
 $theme-site-navbar-primary-link-padding:                  8px !default;
 
 $theme-site-navbar-primary-decorations: (
-  default: $theme-site-navbar-primary-link-decoration,
-  hover: $theme-site-navbar-primary-link-hover-decoration,
-  active: $theme-site-navbar-primary-link-active-decoration
+  default:  $theme-site-navbar-primary-link-decoration,
+  hover:    $theme-site-navbar-primary-link-hover-decoration,
+  active:   $theme-site-navbar-primary-link-active-decoration
 );
 
 $theme-site-navbar-primary-background-colors: (
-  default: $theme-site-navbar-primary-link-background-color,
-  hover: $theme-site-navbar-primary-link-hover-background-color,
-  active: $theme-site-navbar-primary-link-active-background-color
+  default:  $theme-site-navbar-primary-link-background-color,
+  hover:    $theme-site-navbar-primary-link-hover-background-color,
+  active:   $theme-site-navbar-primary-link-active-background-color
 );
 
 
@@ -89,15 +89,15 @@ $theme-site-navbar-secondary-link-hover-decoration:         underline !default;
 $theme-site-navbar-secondary-link-padding:                  8px !default;
 
 $theme-site-navbar-secondary-decorations: (
-  default: $theme-site-navbar-secondary-link-decoration,
-  hover: $theme-site-navbar-secondary-link-hover-decoration,
-  active: $theme-site-navbar-secondary-link-active-decoration
+  default:  $theme-site-navbar-secondary-link-decoration,
+  hover:    $theme-site-navbar-secondary-link-hover-decoration,
+  active:   $theme-site-navbar-secondary-link-active-decoration
 );
 
 $theme-site-navbar-secondary-background-colors: (
-  default: $theme-site-navbar-secondary-link-background-color,
-  hover: $theme-site-navbar-secondary-link-hover-background-color,
-  active: $theme-site-navbar-secondary-link-active-background-color
+  default:  $theme-site-navbar-secondary-link-background-color,
+  hover:    $theme-site-navbar-secondary-link-hover-background-color,
+  active:   $theme-site-navbar-secondary-link-active-background-color
 );
 
 // Effects

--- a/packages/themes/default/styles/variables/_navbar.scss
+++ b/packages/themes/default/styles/variables/_navbar.scss
@@ -18,6 +18,11 @@ $theme-site-navbar-light-color:         rgba($black, .75) !default;
 $theme-site-navbar-light-hover-color:   $black !default;
 $theme-site-navbar-light-active-color:  $theme-site-navbar-light-hover-color !default;
 
+// Lighter
+$theme-site-navbar-lighter-color:         $black !default;
+$theme-site-navbar-lighter-hover-color:   $primary !default;
+$theme-site-navbar-lighter-active-color:  $theme-site-navbar-lighter-hover-color !default;
+
 // Themes
 $theme-site-navbar-map: (
   dark: (
@@ -29,6 +34,11 @@ $theme-site-navbar-map: (
     default:  $theme-site-navbar-light-color,
     hover:    $theme-site-navbar-light-hover-color,
     active:   $theme-site-navbar-light-active-color
+  ),
+  lighter: (
+    default:  $theme-site-navbar-lighter-color,
+    hover:    $theme-site-navbar-lighter-hover-color,
+    active:   $theme-site-navbar-lighter-active-color
   )
 );
 

--- a/packages/themes/default/styles/variables/_navbar.scss
+++ b/packages/themes/default/styles/variables/_navbar.scss
@@ -1,0 +1,115 @@
+/* Navbar */
+
+//  Spacing
+$theme-site-navbar-padding-x:           16px !default;
+$theme-site-navbar-padding-y:           0 !default;
+$theme-site-navbar-brand-margin-y: 0 !default;
+$theme-site-navbar-brand-margin-x: 12px !default;
+
+// Colors
+
+  // Dark
+  $theme-site-navbar-dark-color:          rgba($white, .75) !default;
+  $theme-site-navbar-dark-hover-color:    $white !default;
+  $theme-site-navbar-dark-active-color:   $theme-site-navbar-dark-hover-color !default;
+
+  // Light
+  $theme-site-navbar-light-color:         rgba($black, .75) !default;
+  $theme-site-navbar-light-hover-color:   $black !default;
+  $theme-site-navbar-light-active-color:  $theme-site-navbar-light-hover-color !default;
+
+// Themes
+$theme-site-navbar-map: (
+  dark: (
+    default: $theme-site-navbar-dark-color,
+    hover: $theme-site-navbar-dark-hover-color,
+    active: $theme-site-navbar-dark-active-color
+  ),
+  light: (
+    default: $theme-site-navbar-light-color,
+    hover: $theme-site-navbar-light-hover-color,
+    active: $theme-site-navbar-light-active-color
+  )
+);
+
+
+// Levels
+
+  // Primary
+  $theme-site-navbar-primary-bg-color:        $primary !default;
+  $theme-site-navbar-primary-font-family:     $theme-site-header-font-family !default;
+  $theme-site-navbar-primary-font-size:       16px !default;
+  $theme-site-navbar-primary-font-size-sm:    $theme-site-navbar-primary-font-size - 2 !default;
+  $theme-site-navbar-primary-font-weight:     $font-weight-normal !default;
+  $theme-site-navbar-primary-height-sm:       4px !default;
+  $theme-site-navbar-primary-line-height:     get-line-height($theme-site-navbar-primary-font-size, 24px) !default;
+  $theme-site-navbar-primary-line-height-sm:  get-line-height($theme-site-navbar-primary-font-size-sm, 21px) !default;
+  $theme-site-navbar-primary-padding-x:       16px !default;
+  $theme-site-navbar-primary-padding-y:       0 !default;
+
+  $theme-site-navbar-primary-link-active-background-color:  initial !default;
+  $theme-site-navbar-primary-link-active-decoration:        underline !default;
+  $theme-site-navbar-primary-link-background-color:         initial !default;
+  $theme-site-navbar-primary-link-decoration:               none !default;
+  $theme-site-navbar-primary-link-hover-background-color:   initial !default;
+  $theme-site-navbar-primary-link-hover-decoration:         underline !default;
+  $theme-site-navbar-primary-link-padding:                  8px !default;
+
+  $theme-site-navbar-primary-decorations: (
+    default: $theme-site-navbar-primary-link-decoration,
+    hover: $theme-site-navbar-primary-link-hover-decoration,
+    active: $theme-site-navbar-primary-link-active-decoration
+  );
+
+  $theme-site-navbar-primary-background-colors: (
+    default: $theme-site-navbar-primary-link-background-color,
+    hover: $theme-site-navbar-primary-link-hover-background-color,
+    active: $theme-site-navbar-primary-link-active-background-color
+  );
+
+
+  // Secondary
+  $theme-site-navbar-secondary-bg-color:        $dark !default;
+  $theme-site-navbar-secondary-font-family:     $theme-site-header-font-family !default;
+  $theme-site-navbar-secondary-font-size:       14px !default;
+  $theme-site-navbar-secondary-font-size-sm:    $theme-site-navbar-secondary-font-size - 2 !default;
+  $theme-site-navbar-secondary-font-weight:     $font-weight-normal !default;
+  $theme-site-navbar-secondary-line-height:     get-line-height($theme-site-navbar-secondary-font-size, 21px) !default;
+  $theme-site-navbar-secondary-line-height-sm:  get-line-height($theme-site-navbar-secondary-font-size-sm, 18px) !default;
+  $theme-site-navbar-secondary-padding-x:       16px !default;
+  $theme-site-navbar-secondary-padding-y:       10px !default;
+  $theme-site-navbar-secondary-type:            dark !default;
+
+  $theme-site-navbar-secondary-link-active-background-color:  initial !default;
+  $theme-site-navbar-secondary-link-active-decoration:        underline !default;
+  $theme-site-navbar-secondary-link-background-color:         initial !default;
+  $theme-site-navbar-secondary-link-decoration:               none !default;
+  $theme-site-navbar-secondary-link-hover-background-color:   initial !default;
+  $theme-site-navbar-secondary-link-hover-decoration:         underline !default;
+  $theme-site-navbar-secondary-link-padding:                  8px !default;
+
+  $theme-site-navbar-secondary-decorations: (
+    default: $theme-site-navbar-secondary-link-decoration,
+    hover: $theme-site-navbar-secondary-link-hover-decoration,
+    active: $theme-site-navbar-secondary-link-active-decoration
+  );
+
+  $theme-site-navbar-secondary-background-colors: (
+    default: $theme-site-navbar-secondary-link-background-color,
+    hover: $theme-site-navbar-secondary-link-hover-background-color,
+    active: $theme-site-navbar-secondary-link-active-background-color
+  );
+
+// Effects
+$theme-site-navbar-link-transition: color ease 300ms, text-decoration ease 300ms, background-color ease 300ms !default;
+
+$theme-site-navbar-logo-drop-shadow:   1px 1px 1px rgba(0, 0, 0, .35) !default;
+$theme-site-navbar-logo-height:        60px !default;
+$theme-site-navbar-logo-height-sm:     $theme-site-navbar-logo-height / 2 !default;
+
+$theme-site-navbar-icon-transition:  fill ease 300ms !default;
+
+$theme-site-navbar-menu-box-shadow:             0 8px 17px 0 rgba(0, 0, 0, .2), 0 6px 20px 0 rgba(0, 0, 0, .19) !default;
+$theme-site-navbar-menu-width:                  264px !default;
+$theme-site-navbar-menu-max-width:              75vw !default;
+$theme-site-navbar-menu-hover-background-color: lighten($theme-site-navbar-primary-bg-color, 60%) !default;

--- a/packages/themes/default/styles/variables/_navbar.scss
+++ b/packages/themes/default/styles/variables/_navbar.scss
@@ -8,15 +8,15 @@ $theme-site-navbar-brand-margin-x: 12px !default;
 
 // Colors
 
-  // Dark
-  $theme-site-navbar-dark-color:          rgba($white, .75) !default;
-  $theme-site-navbar-dark-hover-color:    $white !default;
-  $theme-site-navbar-dark-active-color:   $theme-site-navbar-dark-hover-color !default;
+// Dark
+$theme-site-navbar-dark-color:          rgba($white, .75) !default;
+$theme-site-navbar-dark-hover-color:    $white !default;
+$theme-site-navbar-dark-active-color:   $theme-site-navbar-dark-hover-color !default;
 
-  // Light
-  $theme-site-navbar-light-color:         rgba($black, .75) !default;
-  $theme-site-navbar-light-hover-color:   $black !default;
-  $theme-site-navbar-light-active-color:  $theme-site-navbar-light-hover-color !default;
+// Light
+$theme-site-navbar-light-color:         rgba($black, .75) !default;
+$theme-site-navbar-light-hover-color:   $black !default;
+$theme-site-navbar-light-active-color:  $theme-site-navbar-light-hover-color !default;
 
 // Themes
 $theme-site-navbar-map: (

--- a/packages/themes/default/styles/variables/_navbar.scss
+++ b/packages/themes/default/styles/variables/_navbar.scss
@@ -35,70 +35,70 @@ $theme-site-navbar-map: (
 
 // Levels
 
-  // Primary
-  $theme-site-navbar-primary-bg-color:        $primary !default;
-  $theme-site-navbar-primary-font-family:     $theme-site-header-font-family !default;
-  $theme-site-navbar-primary-font-size:       16px !default;
-  $theme-site-navbar-primary-font-size-sm:    $theme-site-navbar-primary-font-size - 2 !default;
-  $theme-site-navbar-primary-font-weight:     $font-weight-normal !default;
-  $theme-site-navbar-primary-height-sm:       4px !default;
-  $theme-site-navbar-primary-line-height:     get-line-height($theme-site-navbar-primary-font-size, 24px) !default;
-  $theme-site-navbar-primary-line-height-sm:  get-line-height($theme-site-navbar-primary-font-size-sm, 21px) !default;
-  $theme-site-navbar-primary-padding-x:       16px !default;
-  $theme-site-navbar-primary-padding-y:       0 !default;
+// Primary
+$theme-site-navbar-primary-bg-color:        $primary !default;
+$theme-site-navbar-primary-font-family:     $theme-site-header-font-family !default;
+$theme-site-navbar-primary-font-size:       16px !default;
+$theme-site-navbar-primary-font-size-sm:    $theme-site-navbar-primary-font-size - 2 !default;
+$theme-site-navbar-primary-font-weight:     $font-weight-normal !default;
+$theme-site-navbar-primary-height-sm:       4px !default;
+$theme-site-navbar-primary-line-height:     get-line-height($theme-site-navbar-primary-font-size, 24px) !default;
+$theme-site-navbar-primary-line-height-sm:  get-line-height($theme-site-navbar-primary-font-size-sm, 21px) !default;
+$theme-site-navbar-primary-padding-x:       16px !default;
+$theme-site-navbar-primary-padding-y:       0 !default;
 
-  $theme-site-navbar-primary-link-active-background-color:  initial !default;
-  $theme-site-navbar-primary-link-active-decoration:        underline !default;
-  $theme-site-navbar-primary-link-background-color:         initial !default;
-  $theme-site-navbar-primary-link-decoration:               none !default;
-  $theme-site-navbar-primary-link-hover-background-color:   initial !default;
-  $theme-site-navbar-primary-link-hover-decoration:         underline !default;
-  $theme-site-navbar-primary-link-padding:                  8px !default;
+$theme-site-navbar-primary-link-active-background-color:  initial !default;
+$theme-site-navbar-primary-link-active-decoration:        underline !default;
+$theme-site-navbar-primary-link-background-color:         initial !default;
+$theme-site-navbar-primary-link-decoration:               none !default;
+$theme-site-navbar-primary-link-hover-background-color:   initial !default;
+$theme-site-navbar-primary-link-hover-decoration:         underline !default;
+$theme-site-navbar-primary-link-padding:                  8px !default;
 
-  $theme-site-navbar-primary-decorations: (
-    default: $theme-site-navbar-primary-link-decoration,
-    hover: $theme-site-navbar-primary-link-hover-decoration,
-    active: $theme-site-navbar-primary-link-active-decoration
-  );
+$theme-site-navbar-primary-decorations: (
+  default: $theme-site-navbar-primary-link-decoration,
+  hover: $theme-site-navbar-primary-link-hover-decoration,
+  active: $theme-site-navbar-primary-link-active-decoration
+);
 
-  $theme-site-navbar-primary-background-colors: (
-    default: $theme-site-navbar-primary-link-background-color,
-    hover: $theme-site-navbar-primary-link-hover-background-color,
-    active: $theme-site-navbar-primary-link-active-background-color
-  );
+$theme-site-navbar-primary-background-colors: (
+  default: $theme-site-navbar-primary-link-background-color,
+  hover: $theme-site-navbar-primary-link-hover-background-color,
+  active: $theme-site-navbar-primary-link-active-background-color
+);
 
 
-  // Secondary
-  $theme-site-navbar-secondary-bg-color:        $dark !default;
-  $theme-site-navbar-secondary-font-family:     $theme-site-header-font-family !default;
-  $theme-site-navbar-secondary-font-size:       14px !default;
-  $theme-site-navbar-secondary-font-size-sm:    $theme-site-navbar-secondary-font-size - 2 !default;
-  $theme-site-navbar-secondary-font-weight:     $font-weight-normal !default;
-  $theme-site-navbar-secondary-line-height:     get-line-height($theme-site-navbar-secondary-font-size, 21px) !default;
-  $theme-site-navbar-secondary-line-height-sm:  get-line-height($theme-site-navbar-secondary-font-size-sm, 18px) !default;
-  $theme-site-navbar-secondary-padding-x:       16px !default;
-  $theme-site-navbar-secondary-padding-y:       10px !default;
-  $theme-site-navbar-secondary-type:            dark !default;
+// Secondary
+$theme-site-navbar-secondary-bg-color:        $dark !default;
+$theme-site-navbar-secondary-font-family:     $theme-site-header-font-family !default;
+$theme-site-navbar-secondary-font-size:       14px !default;
+$theme-site-navbar-secondary-font-size-sm:    $theme-site-navbar-secondary-font-size - 2 !default;
+$theme-site-navbar-secondary-font-weight:     $font-weight-normal !default;
+$theme-site-navbar-secondary-line-height:     get-line-height($theme-site-navbar-secondary-font-size, 21px) !default;
+$theme-site-navbar-secondary-line-height-sm:  get-line-height($theme-site-navbar-secondary-font-size-sm, 18px) !default;
+$theme-site-navbar-secondary-padding-x:       16px !default;
+$theme-site-navbar-secondary-padding-y:       10px !default;
+$theme-site-navbar-secondary-type:            dark !default;
 
-  $theme-site-navbar-secondary-link-active-background-color:  initial !default;
-  $theme-site-navbar-secondary-link-active-decoration:        underline !default;
-  $theme-site-navbar-secondary-link-background-color:         initial !default;
-  $theme-site-navbar-secondary-link-decoration:               none !default;
-  $theme-site-navbar-secondary-link-hover-background-color:   initial !default;
-  $theme-site-navbar-secondary-link-hover-decoration:         underline !default;
-  $theme-site-navbar-secondary-link-padding:                  8px !default;
+$theme-site-navbar-secondary-link-active-background-color:  initial !default;
+$theme-site-navbar-secondary-link-active-decoration:        underline !default;
+$theme-site-navbar-secondary-link-background-color:         initial !default;
+$theme-site-navbar-secondary-link-decoration:               none !default;
+$theme-site-navbar-secondary-link-hover-background-color:   initial !default;
+$theme-site-navbar-secondary-link-hover-decoration:         underline !default;
+$theme-site-navbar-secondary-link-padding:                  8px !default;
 
-  $theme-site-navbar-secondary-decorations: (
-    default: $theme-site-navbar-secondary-link-decoration,
-    hover: $theme-site-navbar-secondary-link-hover-decoration,
-    active: $theme-site-navbar-secondary-link-active-decoration
-  );
+$theme-site-navbar-secondary-decorations: (
+  default: $theme-site-navbar-secondary-link-decoration,
+  hover: $theme-site-navbar-secondary-link-hover-decoration,
+  active: $theme-site-navbar-secondary-link-active-decoration
+);
 
-  $theme-site-navbar-secondary-background-colors: (
-    default: $theme-site-navbar-secondary-link-background-color,
-    hover: $theme-site-navbar-secondary-link-hover-background-color,
-    active: $theme-site-navbar-secondary-link-active-background-color
-  );
+$theme-site-navbar-secondary-background-colors: (
+  default: $theme-site-navbar-secondary-link-background-color,
+  hover: $theme-site-navbar-secondary-link-hover-background-color,
+  active: $theme-site-navbar-secondary-link-active-background-color
+);
 
 // Effects
 $theme-site-navbar-link-transition: color ease 300ms, text-decoration ease 300ms, background-color ease 300ms !default;

--- a/sites/bizbash/server/styles/components/_directory.scss
+++ b/sites/bizbash/server/styles/components/_directory.scss
@@ -104,7 +104,7 @@
     margin-left: auto;
 
     & > .icon {
-      @include theme-navbar-link-color(( active: $primary, hover: $primary, default: $black ));
+      @include theme-navbar-link-color($theme-site-bizbash-map, lighter);
     }
   }
 }

--- a/sites/bizbash/server/styles/components/_directory.scss
+++ b/sites/bizbash/server/styles/components/_directory.scss
@@ -104,7 +104,7 @@
     margin-left: auto;
 
     & > .icon {
-      @include theme-navbar-link-color($theme-site-bizbash-map, lighter);
+      @include theme-navbar-link-color($theme-site-navbar-map, lighter);
     }
   }
 }

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -147,7 +147,11 @@ $theme-site-navbar-primary-font-size:       18.5px;
 $theme-site-navbar-primary-font-size-sm:    16px;
 $theme-site-navbar-primary-font-weight:     700;
 $theme-site-navbar-primary-line-height:     1;
+
+$theme-site-navbar-primary-link-active-color:       $primary;
 $theme-site-navbar-primary-link-active-decoration:  none;
+$theme-site-navbar-primary-link-color:              #fff;
+$theme-site-navbar-primary-link-hover-color:        #fff;
 
 $theme-site-navbar-secondary-bg-color:      $black;
 $theme-site-navbar-secondary-font-size:     12px;
@@ -156,19 +160,13 @@ $theme-site-navbar-secondary-font-family:   $font-roboto-condensed;
 $theme-site-navbar-secondary-font-weight:   700;
 $theme-site-navbar-secondary-line-height:   1;
 
-/* Adding these variables back in due to conflicts with merges done since refactor was started. These were replaced in the refactor by the new mixin system. To be removed after conflict is resolved. */
-$theme-site-navbar-primary-link-active-color:       $primary;
-$theme-site-navbar-primary-link-color:              $white;
-$theme-site-navbar-primary-link-hover-color:        $white;
-
 $theme-site-navbar-secondary-link-color:              $primary;
 $theme-site-navbar-secondary-link-active-decoration:  none;
 $theme-site-navbar-secondary-hover-color:             $primary;
+
 $theme-site-navbar-tertiary-link-active-color:  $white;
 $theme-site-navbar-tertiary-link-color:         $white;
 $theme-site-navbar-tertiary-link-hover-color:   $white;
-
-// end of variables added back in to remove conflict
 
 $theme-site-navbar-menu-hover-background-color: lighten($primary, 60%);
 

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -297,6 +297,10 @@ body {
     background-color: $primary;
   }
 
+  &--shadow {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, .15);
+  }
+
   // @todo Move to core?
   &--latest-issue {
     padding-right: 0;
@@ -324,6 +328,9 @@ body {
         position: relative;
       }
       &__image {
+        &--16by9 {
+          @include theme-embed-responsive(16, 9);
+        }
         &--6by5 {
           @include theme-embed-responsive(6, 5);
         }
@@ -368,6 +375,15 @@ body {
       }
       &__website-section-name {
         margin-right: map-get($spacers, 2);
+      }
+    }
+  }
+
+  &--featured-venue-supplier {
+    #{ $self } {
+      &__contents {
+        padding-right: 0;
+        padding-left: 0;
       }
     }
   }
@@ -426,15 +442,6 @@ body {
   }
 }
 
-// @todo move to core
-.page-right-rail > * {
-  margin-bottom: map-get($spacers, block);
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-}
-
 .item-list {
   $self: &;
   // @todo Add to core
@@ -474,6 +481,16 @@ body {
         &:last-child {
           border-bottom: 4px solid $gray-200;
         }
+      }
+    }
+  }
+  &--featured-venues-suppliers {
+    margin-bottom: map-get($spacers, block);
+    #{ $self } {
+      &__header,
+      &__item {
+        font-size: 20px;
+        background-color: $gray-200;
       }
     }
   }

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -231,7 +231,6 @@ body {
         content: "";
       }
       &__link {
-        @include theme-navbar-link-color($theme-site-navbar-map, dark);
         &::before {
           float: left;
           padding-right: $theme-site-navbar-primary-padding-x - 1;
@@ -244,11 +243,6 @@ body {
   &--secondary {
     #{ $self }__link {
       @include theme-navbar-link-color($theme-site-navbar-map, light);
-    }
-  }
-  &--tertiary {
-    #{ $self }__link {
-      @include theme-navbar-link-color($theme-site-navbar-map, dark);
     }
   }
 }

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -156,7 +156,7 @@ $theme-site-navbar-secondary-font-family:   $font-roboto-condensed;
 $theme-site-navbar-secondary-font-weight:   700;
 $theme-site-navbar-secondary-line-height:   1;
 
-/* Adding these variables back in due to conflicts with merges done since refactor was started. These were replaced in the refactor by the new mixin system. */
+/* Adding these variables back in due to conflicts with merges done since refactor was started. These were replaced in the refactor by the new mixin system. To be removed after conflict is resolved. */
 $theme-site-navbar-primary-link-active-color:       $primary;
 $theme-site-navbar-primary-link-color:              $white;
 $theme-site-navbar-primary-link-hover-color:        $white;

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -19,8 +19,27 @@ $black:     #000;
 $white:     #fff;
 $gray-600:  #4d4d4d;
 
+// Map
+$theme-site-bizbash-map: (
+  dark: (
+    default: $white,
+    hover: $white,
+    active: $white
+  ),
+  light: (
+    default: $primary,
+    hover: $white,
+    active: $white
+  ),
+  lighter: (
+    default: $black,
+    hover: $primary,
+    active: $primary
+  )
+);
+
 // General Settings
-$body-bg:     #fff;
+$body-bg:     $white;
 $body-color:  #333;
 $list-group-border-width: 0;
 $enable-shadows: false;
@@ -104,7 +123,7 @@ $theme-breadcrumbs-font-weight:   600;
 
 // Cards
 $theme-card-header-color:             $primary;
-$theme-card-header-background-color:  #fff;
+$theme-card-header-background-color:  $white;
 $theme-card-header-border:            none;
 $theme-card-header-font-family:       $font-oswald;
 $theme-card-header-font-size:         26.825px;
@@ -142,11 +161,7 @@ $theme-site-navbar-primary-font-size:       18.5px;
 $theme-site-navbar-primary-font-size-sm:    16px;
 $theme-site-navbar-primary-font-weight:     700;
 $theme-site-navbar-primary-line-height:     1;
-
-$theme-site-navbar-primary-link-active-color:       $primary;
 $theme-site-navbar-primary-link-active-decoration:  none;
-$theme-site-navbar-primary-link-color:              #fff;
-$theme-site-navbar-primary-link-hover-color:        #fff;
 
 $theme-site-navbar-secondary-bg-color:      $black;
 $theme-site-navbar-secondary-font-size:     12px;
@@ -154,13 +169,6 @@ $theme-site-navbar-secondary-font-size-sm:  12px;
 $theme-site-navbar-secondary-font-family:   $font-roboto-condensed;
 $theme-site-navbar-secondary-font-weight:   700;
 $theme-site-navbar-secondary-line-height:   1;
-
-$theme-site-navbar-secondary-link-color:    $primary;
-$theme-site-navbar-secondary-hover-color:   $primary;
-
-$theme-site-navbar-tertiary-link-active-color:  $white;
-$theme-site-navbar-tertiary-link-color:         $white;
-$theme-site-navbar-tertiary-link-hover-color:   $white;
 
 $theme-site-navbar-menu-hover-background-color: lighten($primary, 60%);
 
@@ -237,6 +245,7 @@ body {
         content: "";
       }
       &__link {
+        @include theme-navbar-link-color($theme-site-bizbash-map, dark);
         &::before {
           float: left;
           padding-right: $theme-site-navbar-primary-padding-x - 1;
@@ -246,6 +255,24 @@ body {
       }
     }
   }
+  &--secondary {
+    #{ $self } {
+      &__link {
+        @include theme-navbar-link-color($theme-site-bizbash-map, light);
+      }
+    }
+  }
+  &--tertiary {
+    #{ $self } {
+      &__link {
+        @include theme-navbar-link-color($theme-site-bizbash-map, dark);
+      }
+    }
+  }
+}
+
+.site-navbar-toggler > .icon {
+  @include theme-navbar-link-color($theme-site-bizbash-map, light);
 }
 
 .website-scheduled-content-hero {

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -156,6 +156,20 @@ $theme-site-navbar-secondary-font-family:   $font-roboto-condensed;
 $theme-site-navbar-secondary-font-weight:   700;
 $theme-site-navbar-secondary-line-height:   1;
 
+/* Adding these variables back in due to conflicts with merges done since refactor was started. These were replaced in the refactor by the new mixin system. */
+$theme-site-navbar-primary-link-active-color:       $primary;
+$theme-site-navbar-primary-link-color:              $white;
+$theme-site-navbar-primary-link-hover-color:        $white;
+
+$theme-site-navbar-secondary-link-color:              $primary;
+$theme-site-navbar-secondary-link-active-decoration:  none;
+$theme-site-navbar-secondary-hover-color:             $primary;
+$theme-site-navbar-tertiary-link-active-color:  $white;
+$theme-site-navbar-tertiary-link-color:         $white;
+$theme-site-navbar-tertiary-link-hover-color:   $white;
+
+// end of variables added back in to remove conflict
+
 $theme-site-navbar-menu-hover-background-color: lighten($primary, 60%);
 
 $theme-site-navbar-logo-height: 45px;
@@ -484,6 +498,7 @@ body {
       }
     }
   }
+
   &--featured-venues-suppliers {
     margin-bottom: map-get($spacers, block);
     #{ $self } {

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -19,24 +19,10 @@ $black:     #000;
 $white:     #fff;
 $gray-600:  #4d4d4d;
 
-// Map
-$theme-site-bizbash-map: (
-  dark: (
-    default: $white,
-    hover: $white,
-    active: $white
-  ),
-  light: (
-    default: $primary,
-    hover: $white,
-    active: $white
-  ),
-  lighter: (
-    default: $black,
-    hover: $primary,
-    active: $primary
-  )
-);
+// Common Theme Color Overrides
+$theme-site-navbar-dark-color:          $white;
+$theme-site-navbar-light-color:         $primary;
+$theme-site-navbar-light-hover-color:   $white;
 
 // General Settings
 $body-bg:     $white;
@@ -245,7 +231,7 @@ body {
         content: "";
       }
       &__link {
-        @include theme-navbar-link-color($theme-site-bizbash-map, dark);
+        @include theme-navbar-link-color($theme-site-navbar-map, dark);
         &::before {
           float: left;
           padding-right: $theme-site-navbar-primary-padding-x - 1;
@@ -257,18 +243,18 @@ body {
   }
   &--secondary {
     #{ $self }__link {
-      @include theme-navbar-link-color($theme-site-bizbash-map, light);
+      @include theme-navbar-link-color($theme-site-navbar-map, light);
     }
   }
   &--tertiary {
     #{ $self }__link {
-      @include theme-navbar-link-color($theme-site-bizbash-map, dark);
+      @include theme-navbar-link-color($theme-site-navbar-map, dark);
     }
   }
 }
 
 .site-navbar-toggler > .icon {
-  @include theme-navbar-link-color($theme-site-bizbash-map, light);
+  @include theme-navbar-link-color($theme-site-navbar-map, light);
 }
 
 .website-scheduled-content-hero {

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -256,17 +256,13 @@ body {
     }
   }
   &--secondary {
-    #{ $self } {
-      &__link {
-        @include theme-navbar-link-color($theme-site-bizbash-map, light);
-      }
+    #{ $self }__link {
+      @include theme-navbar-link-color($theme-site-bizbash-map, light);
     }
   }
   &--tertiary {
-    #{ $self } {
-      &__link {
-        @include theme-navbar-link-color($theme-site-bizbash-map, dark);
-      }
+    #{ $self }__link {
+      @include theme-navbar-link-color($theme-site-bizbash-map, dark);
     }
   }
 }


### PR DESCRIPTION
Theme Sass Refactoring 
-- Phase 1: Navbar
---- Stage 1: Navbar Link Colors

**_variables:**
- Removed unnecessary variable settings
- Added variable folder, with _navbar subfile
- Moved navbar settings into _navbar subfile
- Added import for _navbar subfile
- Created nested color map for navbar themes (currently only contains link settings, per Stage 1 objective)

**_functions:** 
- Updated map function to be usable across multiple map types, including nested maps
- Removed old navbar link function

**_mixins**
- Updated theme-navbar-link-color to utilize new function and theme map

**themes/_navbar**
- Updated mixin calls to utilize new format, referencing new map and theme key

**bizbash _directory**
- Updated theme-navbar-link-color to reference new map and theme key

**bizbash index**
- Added theme map for bizbash custom theme
- Updated theme-navbar-link-color references to bizbash map and theme keys
- Removed unused variables
- Updated #fff references to use $white

ToDo: reduce bizbash line additions?

Next Stage -- Stage 2: Navbar Decorations & Backgrounds