### PR TITLE
Dynamic-Page-Body: replaced reference

### DIFF
--- a/sites/aquamagazine/server/templates/dynamic-page/index.marko
+++ b/sites/aquamagazine/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/athleticbusiness/server/templates/dynamic-page/index.marko
+++ b/sites/athleticbusiness/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/automationworld/server/templates/dynamic-page/index.marko
+++ b/sites/automationworld/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/bioopticsworld/server/templates/dynamic-page/index.marko
+++ b/sites/bioopticsworld/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/bizbash/server/templates/dynamic-page/index.marko
+++ b/sites/bizbash/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/broadbandtechreport/server/templates/dynamic-page/index.marko
+++ b/sites/broadbandtechreport/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/cablinginstall/server/templates/dynamic-page/index.marko
+++ b/sites/cablinginstall/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/clevescene/server/templates/dynamic-page/index.marko
+++ b/sites/clevescene/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/dentaleconomics/server/templates/dynamic-page/index.marko
+++ b/sites/dentaleconomics/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/dentistryiq/server/templates/dynamic-page/index.marko
+++ b/sites/dentistryiq/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/evaluationengineering/server/templates/dynamic-page/index.marko
+++ b/sites/evaluationengineering/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/forconstructionpros/server/templates/dynamic-page/index.marko
+++ b/sites/forconstructionpros/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/healthcarepackaging/server/templates/dynamic-page/index.marko
+++ b/sites/healthcarepackaging/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/industrial-lasers/server/templates/dynamic-page/index.marko
+++ b/sites/industrial-lasers/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/intelligent-aerospace/server/templates/dynamic-page/index.marko
+++ b/sites/intelligent-aerospace/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/laserfocusworld/server/templates/dynamic-page/index.marko
+++ b/sites/laserfocusworld/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/ledsmagazine/server/templates/dynamic-page/index.marko
+++ b/sites/ledsmagazine/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/lightwaveonline/server/templates/dynamic-page/index.marko
+++ b/sites/lightwaveonline/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/metrotimes/server/templates/dynamic-page/index.marko
+++ b/sites/metrotimes/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/militaryaerospace/server/templates/dynamic-page/index.marko
+++ b/sites/militaryaerospace/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/mundopmmi/server/templates/dynamic-page/index.marko
+++ b/sites/mundopmmi/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/oemmagazine/server/templates/dynamic-page/index.marko
+++ b/sites/oemmagazine/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/officer/server/templates/dynamic-page/index.marko
+++ b/sites/officer/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/offshore-mag/server/templates/dynamic-page/index.marko
+++ b/sites/offshore-mag/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/ogj/server/templates/dynamic-page/index.marko
+++ b/sites/ogj/server/templates/dynamic-page/index.marko
@@ -23,7 +23,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/orlandoweekly/server/templates/dynamic-page/index.marko
+++ b/sites/orlandoweekly/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/outinsa/server/templates/dynamic-page/index.marko
+++ b/sites/outinsa/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/outinstl/server/templates/dynamic-page/index.marko
+++ b/sites/outinstl/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/packworld/server/templates/dynamic-page/index.marko
+++ b/sites/packworld/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/perioimplantadvisory/server/templates/dynamic-page/index.marko
+++ b/sites/perioimplantadvisory/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/plasticsmachinerymagazine/server/templates/dynamic-page/index.marko
+++ b/sites/plasticsmachinerymagazine/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/profoodworld/server/templates/dynamic-page/index.marko
+++ b/sites/profoodworld/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/rdhmag/server/templates/dynamic-page/index.marko
+++ b/sites/rdhmag/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/riverfronttimes/server/templates/dynamic-page/index.marko
+++ b/sites/riverfronttimes/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/sacurrent/server/templates/dynamic-page/index.marko
+++ b/sites/sacurrent/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/strategies-u/server/templates/dynamic-page/index.marko
+++ b/sites/strategies-u/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/utilityproducts/server/templates/dynamic-page/index.marko
+++ b/sites/utilityproducts/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/vision-systems/server/templates/dynamic-page/index.marko
+++ b/sites/vision-systems/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/waterworld/server/templates/dynamic-page/index.marko
+++ b/sites/waterworld/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>

--- a/sites/woodfloorbusiness/server/templates/dynamic-page/index.marko
+++ b/sites/woodfloorbusiness/server/templates/dynamic-page/index.marko
@@ -22,7 +22,7 @@ $ const page = getAsObject(data, 'page');
           </div>
         </div>
         <div class="page-wrapper__contents">
-          $!{page.body}
+          <cms-content-body tag="div" obj=page />
         </div>
       </div>
     </div>


### PR DESCRIPTION
 $!{page.body} to <cms-content-body tag="div" obj=page />, per Jacob

Correct image display issues on dynamic page templates, ie: URLs referenced under /page

https://www.bizbash.com/page/our-events
![image](https://user-images.githubusercontent.com/6343242/62397142-8d029c80-b53a-11e9-86c0-df2470b57ac5.png)

https://www.bizbash.com/page/about-us
<img width="1128" alt="Screen Shot 2019-08-02 at 3 31 16 PM" src="https://user-images.githubusercontent.com/6343242/62397166-9f7cd600-b53a-11e9-8549-744688cc0ec5.png">
