### PR TITLE
Display sticky leaderboard only after scroll offset is reached

### DIFF
--- a/packages/common/browser/sticky-leaderboard.vue
+++ b/packages/common/browser/sticky-leaderboard.vue
@@ -19,6 +19,7 @@
 </template>
 
 <script>
+import ScrollMagic from 'scrollmagic/scrollmagic/minified/ScrollMagic.min';
 import IconX from '../icons/vue/x.vue';
 
 const buildSizeMapping = sm => sm
@@ -63,6 +64,10 @@ export default {
         { viewport: [320, 0], size: [[300, 50], [320, 50], [300, 100]] },
       ],
     },
+    scrollOffset: {
+      type: Number,
+      default: 1000,
+    },
   },
   data() {
     return {
@@ -70,6 +75,7 @@ export default {
       intervalMs: this.interval * 1000,
       handler: null,
       visible: false,
+      initialized: false,
     };
   },
   computed: {
@@ -94,6 +100,19 @@ export default {
   },
   mounted() {
     if (this.canDisplay) {
+      const controller = new ScrollMagic.Controller();
+      const scene = new ScrollMagic.Scene({ offset: this.scrollOffset });
+      scene.on('enter', () => {
+        if (!this.initialized) this.init();
+      });
+      controller.addScene(scene);
+    }
+  },
+  beforeDestroy() {
+    if (this.canDisplay) clearTimeout(this.handler);
+  },
+  methods: {
+    init() {
       const { googletag } = window;
       googletag.cmd.push(() => {
         googletag.pubads().addEventListener('slotRenderEnded', this.display);
@@ -104,12 +123,8 @@ export default {
           .addService(googletag.pubads());
         googletag.display(this.id);
       });
-    }
-  },
-  beforeDestroy() {
-    if (this.canDisplay) clearTimeout(this.handler);
-  },
-  methods: {
+      this.initialized = true;
+    },
     close() {
       this.visible = false;
       clearTimeout(this.handler);

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,6 +19,7 @@
     "graphql-tag": "^2.10.1",
     "helmet": "^3.16.0",
     "node-fetch": "^2.5.0",
+    "scrollmagic": "^2.0.7",
     "vue-recaptcha": "^1.1.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9832,6 +9832,11 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
+scrollmagic@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/scrollmagic/-/scrollmagic-2.0.7.tgz#4139216f3849d226e38b3ef1e5dbbacf25190b35"
+  integrity sha512-Qu23XB3YTBhqbnTIkyVhVAEP/7r2APvW+QFfxCpd6LvJ5byCnlvSMzSeBdpyKbDKXBxVWGE9XFXUTvue3B7VrQ==
+
 scss-tokenizer@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"


### PR DESCRIPTION
- will prevent display of the sticky leaderboard until the specified `scrollOffset` is reached (default 1000 pixels)
- uses the (minified) `scrollmagic` library (adds 17k [non-gzipped] ~6k [gzipped] to JS file size)