### PR TITLE
Use 16:9 images with venue/supplier carousel

### DIFF
--- a/sites/bizbash/components/image-slider.marko
+++ b/sites/bizbash/components/image-slider.marko
@@ -2,12 +2,12 @@ import { getAsArray } from '@base-cms/object-path';
 import imageFormat from './image-format';
 
 $ const imageOptions = {
+  ar: '16:9',
   fit: 'crop',
   crop: 'focalpoint',
   fpX: 0.5,
   fpY: 0.5,
-  w: 1200,
-  h: 515,
+  w: 1140,
 };
 $ const images = getAsArray(input, 'images').map(node => imageFormat(node, imageOptions));
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3289485/62472832-30cf9080-b765-11e9-828a-c3af501f355a.png)
