### PR TITLE
Create non-overlay card item and deck

### DIFF
--- a/sites/bizbash/components/card-item.marko
+++ b/sites/bizbash/components/card-item.marko
@@ -1,0 +1,37 @@
+import { getAsObject } from '@base-cms/object-path';
+
+$ const content = getAsObject(input, 'content');
+$ const primarySection = getAsObject(content, 'primarySection');
+$ const primaryImage = getAsObject(content, 'primaryImage');
+$ const dateFormat = 'MMMM D, YYYY';
+$ const imageInput = {
+  image: primaryImage,
+  lazyload: false,
+  linkTo: content,
+  modifiers: ['fluid', '16by9'],
+  options: { ar: '16:9', w: 630, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 },
+  position: 'top',
+  usePlaceholder: false,
+  ...getAsObject(input, 'image'),
+};
+
+<endeavor-item modifiers=["card", "shadow"]>
+  <@image ...imageInput />
+  <@title tag="h5">
+    <cms-content-short-name tag=null obj=content link=true />
+  </@title>
+  <@footer-left|{ block }|>
+    <cms-website-section-name tag="span" block=block obj=primarySection link=true />
+  </@footer-left>
+  <@footer-right|{ block }|>
+    <if(content.type === "event")>
+      <span class=`${block}__content-event-dates`>
+        <cms-date-element tag="span" field="starts" block=block obj=content format=dateFormat />
+        <cms-date-element tag="span" field="ends" block=block obj=content format=dateFormat />
+      </span>
+    </if>
+    <else>
+      <cms-content-published tag="span" block=block obj=content format=dateFormat />
+    </else>
+  </@footer-right>
+</endeavor-item>

--- a/sites/bizbash/components/load-more/content-layout.marko
+++ b/sites/bizbash/components/load-more/content-layout.marko
@@ -2,11 +2,13 @@ import { getAsArray } from '@base-cms/object-path';
 import DefaultLayout from './content-layouts/default';
 import LargeListLayout from './content-layouts/list-large';
 import GridNoAdsLayout from './content-layouts/grid-no-ads';
+import CardItemDeck from './content-layouts/card-item-deck';
 
 $ const layouts = {
   default: DefaultLayout,
   'list-large': LargeListLayout,
   'grid-no-ads': GridNoAdsLayout,
+  'card-item-deck': CardItemDeck,
 };
 $ const layout = layouts[input.name] || layouts.default;
 $ const nodes = getAsArray(input, 'nodes');

--- a/sites/bizbash/components/load-more/content-layouts/card-item-deck.marko
+++ b/sites/bizbash/components/load-more/content-layouts/card-item-deck.marko
@@ -1,0 +1,11 @@
+$ const { nodes, aliases } = input;
+
+<endeavor-item-card-deck|{ item }| items=nodes>
+  <bizbash-card-item content=item />
+</endeavor-item-card-deck>
+<hr>
+<endeavor-gam-ad-unit-define-display
+  name="lb1"
+  aliases=aliases
+/>
+<hr>

--- a/sites/bizbash/components/marko.json
+++ b/sites/bizbash/components/marko.json
@@ -56,6 +56,14 @@
       },
       "@image": "object"
     },
+    "bizbash-card-item": {
+      "template": "./card-item.marko",
+      "@content": {
+        "type": "object",
+        "required": true
+      },
+      "@image": "object"
+    },
     "bizbash-card-item-overlay": {
       "template": "./card-item-overlay.marko",
       "@content": {

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -295,6 +295,10 @@ body {
     background-color: $primary;
   }
 
+  &--shadow {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, .15);
+  }
+
   // @todo Move to core?
   &--latest-issue {
     padding-right: 0;
@@ -322,6 +326,9 @@ body {
         position: relative;
       }
       &__image {
+        &--16by9 {
+          @include theme-embed-responsive(16, 9);
+        }
         &--6by5 {
           @include theme-embed-responsive(6, 5);
         }

--- a/sites/bizbash/server/templates/published-content/events.marko
+++ b/sites/bizbash/server/templates/published-content/events.marko
@@ -32,8 +32,8 @@ $ const now = (new Date()).valueOf();
   <@below-container>
     <bizbash-load-more
       type="all-published-content"
-      query={ contentTypes: ["Event"], sortField: "startDate", sortOrder: "asc", endingAfter: now, limit: 25 }
-      layout={ name: "list-large" }
+      query={ contentTypes: ["Event"], sortField: "startDate", sortOrder: "asc", endingAfter: now, limit: 18 }
+      layout={ name: "card-item-deck" }
     />
   </@below-container>
 

--- a/sites/bizbash/server/templates/published-content/videos.marko
+++ b/sites/bizbash/server/templates/published-content/videos.marko
@@ -31,8 +31,8 @@ $ const page = pageDetails('Videos', config);
   <@below-container>
     <bizbash-load-more
       type="all-published-content"
-      query={ contentTypes: ["Video"], limit: 25 }
-      layout={ name: "list-large" }
+      query={ contentTypes: ["Video"], limit: 18 }
+      layout={ name: "card-item-deck" }
     />
   </@below-container>
 

--- a/sites/bizbash/server/templates/published-content/webinars.marko
+++ b/sites/bizbash/server/templates/published-content/webinars.marko
@@ -31,8 +31,8 @@ $ const page = pageDetails('Webcasts', config);
   <@below-container>
     <bizbash-load-more
       type="all-published-content"
-      query={ contentTypes: ["Webinar"], limit: 25, sortField: "startDate", sortOrder: "desc" }
-      layout={ name: "list-large" }
+      query={ contentTypes: ["Webinar"], limit: 18, sortField: "startDate", sortOrder: "desc" }
+      layout={ name: "card-item-deck" }
     />
   </@below-container>
 

--- a/sites/bizbash/server/templates/published-content/white-papers.marko
+++ b/sites/bizbash/server/templates/published-content/white-papers.marko
@@ -31,8 +31,8 @@ $ const page = pageDetails('White Papers', config);
   <@below-container>
     <bizbash-load-more
       type="all-published-content"
-      query={ contentTypes: ["Whitepaper"], limit: 25 }
-      layout={ name: "list-large" }
+      query={ contentTypes: ["Whitepaper"], limit: 18 }
+      layout={ name: "card-item-deck" }
       append-to=".page-wrapper"
     />
   </@below-container>

--- a/sites/bizbash/server/templates/website-section/industry-buzz.marko
+++ b/sites/bizbash/server/templates/website-section/industry-buzz.marko
@@ -38,8 +38,8 @@ $ const adSlots = {
   <@below-container>
     <bizbash-load-more
       type="website-scheduled-content"
-      query={ sectionId: section.id, limit: 25, requiresImage: false }
-      layout={ name: "list-large", aliases }
+      query={ sectionId: section.id, limit: 18, requiresImage: false }
+      layout={ name: "card-item-deck", aliases }
     />
   </@below-container>
 


### PR DESCRIPTION
Use on published content pages (e.g. `/video`) and the `/industry-buzz` section.

Video page:
![image](https://user-images.githubusercontent.com/3289485/62481518-3da9af80-b778-11e9-9dbd-fc2d6db0633d.png)

Industry Buzz (no images):
![image](https://user-images.githubusercontent.com/3289485/62481487-2d91d000-b778-11e9-93fb-8aca4704f24a.png)
