### PR TITLE
Add section wrappers to pages and load more

### DIFF
--- a/packages/common/components/content/blocks/query-load-more-author.marko
+++ b/packages/common/components/content/blocks/query-load-more-author.marko
@@ -35,79 +35,81 @@ $ const imageOptions = { w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0
   $ const cardNodes = asArray(nodes.slice(0, 10));
   $ const listNodes = asArray(nodes.slice(10));
   <if(cardNodes.length || listNodes.length)>
-    <if(input.header && pageNumber === 1)>
-      <endeavor-load-more-header>
-        ${input.header}
-      </endeavor-load-more-header>
-    </if>
-    <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
-    <div class=block>
-      <if(cardNodes.length)>
-        <div class="row">
-          <for|content, index| of=cardNodes>
-            <div class=`${block}__col`>
-              <endeavor-content-block-item
-                content=content
-                image-modifiers=["fluid", "21by9"]
-                image-options=imageOptions
-                image-position="top"
-                modifiers=["card"]
-              />
-            </div>
-            <if(index === 1 || index === 6)>
+    <endeavor-page-section>
+      <if(input.header && pageNumber === 1)>
+        <endeavor-load-more-header>
+          ${input.header}
+        </endeavor-load-more-header>
+      </if>
+      <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
+      <div class=block>
+        <if(cardNodes.length)>
+          <div class="row">
+            <for|content, index| of=cardNodes>
               <div class=`${block}__col`>
-                <endeavor-gam-ad-unit-define-display ...adCardInput aliases=adAliases />
-              </div>
-            </if>
-          </for>
-        </div>
-      </if>
-
-      <if(listNodes.length)>
-        <div class="row">
-          <div class=`${block}__col-ad`>
-            <endeavor-gam-ad-unit-define-display ...adListInput aliases=adAliases />
-          </div>
-
-          <div class=`${block}__col-list`>
-            <endeavor-item-list flush=true card=true items=listNodes>
-              <@item|{ item }|>
                 <endeavor-content-block-item
-                  content=item
-                  image-position="left"
-                  image-options={ w: 176, h: 99, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
-                  image-width=176
-                  image-height=99
+                  content=content
+                  image-modifiers=["fluid", "21by9"]
+                  image-options=imageOptions
+                  image-position="top"
+                  modifiers=["card"]
                 />
-              </@item>
-            </endeavor-item-list>
+              </div>
+              <if(index === 1 || index === 6)>
+                <div class=`${block}__col`>
+                  <endeavor-gam-ad-unit-define-display ...adCardInput aliases=adAliases />
+                </div>
+              </if>
+            </for>
           </div>
-        </div>
-      </if>
-    </div>
-    $ const { endCursor, hasNextPage } = pageInfo;
-    $ delete query.skip;
-    $ delete query.queryFragment;
-    $ delete query.renderBody;
-    $ query.after = endCursor;
-    $ const provide = {
-      ...input,
-      query,
-      ads: {
-        aliases: adAliases,
-        card: adCardInput,
-        list: adListInput,
-      },
-    };
+        </if>
 
-    <endeavor-load-more-button
-      append-to=".container-fluid-max"
-      block-name="content-query-load-more-author"
-      label="Load More Content"
-      max-pages=loadMore.maxPages
-      page-number=pageNumber
-      provide=provide
-      show=hasNextPage
-    />
+        <if(listNodes.length)>
+          <div class="row">
+            <div class=`${block}__col-ad`>
+              <endeavor-gam-ad-unit-define-display ...adListInput aliases=adAliases />
+            </div>
+
+            <div class=`${block}__col-list`>
+              <endeavor-item-list flush=true card=true items=listNodes>
+                <@item|{ item }|>
+                  <endeavor-content-block-item
+                    content=item
+                    image-position="left"
+                    image-options={ w: 176, h: 99, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
+                    image-width=176
+                    image-height=99
+                  />
+                </@item>
+              </endeavor-item-list>
+            </div>
+          </div>
+        </if>
+      </div>
+      $ const { endCursor, hasNextPage } = pageInfo;
+      $ delete query.skip;
+      $ delete query.queryFragment;
+      $ delete query.renderBody;
+      $ query.after = endCursor;
+      $ const provide = {
+        ...input,
+        query,
+        ads: {
+          aliases: adAliases,
+          card: adCardInput,
+          list: adListInput,
+        },
+      };
+
+      <endeavor-load-more-button
+        append-to=".container-fluid-max"
+        block-name="content-query-load-more-author"
+        label="Load More Content"
+        max-pages=loadMore.maxPages
+        page-number=pageNumber
+        provide=provide
+        show=hasNextPage
+      />
+    </endeavor-page-section>
   </if>
 </cms-query-all-author-content>

--- a/packages/common/components/content/blocks/query-load-more-company.marko
+++ b/packages/common/components/content/blocks/query-load-more-company.marko
@@ -35,79 +35,81 @@ $ const imageOptions = { w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0
   $ const cardNodes = asArray(nodes.slice(0, 10));
   $ const listNodes = asArray(nodes.slice(10));
   <if(cardNodes.length || listNodes.length)>
-    <if(input.header && pageNumber === 1)>
-      <endeavor-load-more-header>
-        ${input.header}
-      </endeavor-load-more-header>
-    </if>
-    <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
-    <div class=block>
-      <if(cardNodes.length)>
-        <div class="row">
-          <for|content, index| of=cardNodes>
-            <div class=`${block}__col`>
-              <endeavor-content-block-item
-                content=content
-                image-modifiers=["fluid", "21by9"]
-                image-options=imageOptions
-                image-position="top"
-                modifiers=["card"]
-              />
-            </div>
-            <if(index === 1 || index === 6)>
+    <endeavor-page-section>
+      <if(input.header && pageNumber === 1)>
+        <endeavor-load-more-header>
+          ${input.header}
+        </endeavor-load-more-header>
+      </if>
+      <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
+      <div class=block>
+        <if(cardNodes.length)>
+          <div class="row">
+            <for|content, index| of=cardNodes>
               <div class=`${block}__col`>
-                <endeavor-gam-ad-unit-define-display ...adCardInput aliases=adAliases />
-              </div>
-            </if>
-          </for>
-        </div>
-      </if>
-
-      <if(listNodes.length)>
-        <div class="row">
-          <div class=`${block}__col-ad`>
-            <endeavor-gam-ad-unit-define-display ...adListInput aliases=adAliases />
-          </div>
-
-          <div class=`${block}__col-list`>
-            <endeavor-item-list flush=true card=true items=listNodes>
-              <@item|{ item }|>
                 <endeavor-content-block-item
-                  content=item
-                  image-position="left"
-                  image-options={ w: 176, h: 99, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
-                  image-width=176
-                  image-height=99
+                  content=content
+                  image-modifiers=["fluid", "21by9"]
+                  image-options=imageOptions
+                  image-position="top"
+                  modifiers=["card"]
                 />
-              </@item>
-            </endeavor-item-list>
+              </div>
+              <if(index === 1 || index === 6)>
+                <div class=`${block}__col`>
+                  <endeavor-gam-ad-unit-define-display ...adCardInput aliases=adAliases />
+                </div>
+              </if>
+            </for>
           </div>
-        </div>
-      </if>
-    </div>
-    $ const { endCursor, hasNextPage } = pageInfo;
-    $ delete query.skip;
-    $ delete query.queryFragment;
-    $ delete query.renderBody;
-    $ query.after = endCursor;
-    $ const provide = {
-      ...input,
-      query,
-      ads: {
-        aliases: adAliases,
-        card: adCardInput,
-        list: adListInput,
-      },
-    };
+        </if>
 
-    <endeavor-load-more-button
-      append-to=".container-fluid-max"
-      block-name="content-query-load-more-company"
-      label="Load More Content"
-      max-pages=loadMore.maxPages
-      page-number=pageNumber
-      provide=provide
-      show=hasNextPage
-    />
+        <if(listNodes.length)>
+          <div class="row">
+            <div class=`${block}__col-ad`>
+              <endeavor-gam-ad-unit-define-display ...adListInput aliases=adAliases />
+            </div>
+
+            <div class=`${block}__col-list`>
+              <endeavor-item-list flush=true card=true items=listNodes>
+                <@item|{ item }|>
+                  <endeavor-content-block-item
+                    content=item
+                    image-position="left"
+                    image-options={ w: 176, h: 99, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
+                    image-width=176
+                    image-height=99
+                  />
+                </@item>
+              </endeavor-item-list>
+            </div>
+          </div>
+        </if>
+      </div>
+      $ const { endCursor, hasNextPage } = pageInfo;
+      $ delete query.skip;
+      $ delete query.queryFragment;
+      $ delete query.renderBody;
+      $ query.after = endCursor;
+      $ const provide = {
+        ...input,
+        query,
+        ads: {
+          aliases: adAliases,
+          card: adCardInput,
+          list: adListInput,
+        },
+      };
+
+      <endeavor-load-more-button
+        append-to=".container-fluid-max"
+        block-name="content-query-load-more-company"
+        label="Load More Content"
+        max-pages=loadMore.maxPages
+        page-number=pageNumber
+        provide=provide
+        show=hasNextPage
+      />
+    </endeavor-page-section>
   </if>
 </cms-query-all-company-content>

--- a/packages/common/components/content/blocks/query-load-more-issue-content.marko
+++ b/packages/common/components/content/blocks/query-load-more-issue-content.marko
@@ -49,65 +49,67 @@ $ const adListInput = {
   $ const cardNodes = asArray(nodes.slice(0, 10));
   $ const listNodes = asArray(nodes.slice(10));
   <if(cardNodes.length || listNodes.length)>
-    <if(input.header && pageNumber === 1)>
-      <endeavor-load-more-header>
-        ${input.header}
-      </endeavor-load-more-header>
-    </if>
-    <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
-    <div class=block>
-      <if(cardNodes.length)>
-        <div class="row">
-          <for|content, index| of=cardNodes>
-            <div class=`${block}__col`>
-              <endeavor-content-block-item
-                content=content
-                image-modifiers=["fluid", "21by9"]
-                image-options={ w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0.5, fpY: 0.5 }
-                image-position="top"
-                modifiers=["card"]
-              />
-            </div>
-            <if(index === 1 || index === 6)>
+    <endeavor-page-section>
+      <if(input.header && pageNumber === 1)>
+        <endeavor-load-more-header>
+          ${input.header}
+        </endeavor-load-more-header>
+      </if>
+      <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
+      <div class=block>
+        <if(cardNodes.length)>
+          <div class="row">
+            <for|content, index| of=cardNodes>
               <div class=`${block}__col`>
-                <endeavor-gam-ad-unit-define-display ...adCardInput aliases=adAliases />
-              </div>
-            </if>
-          </for>
-        </div>
-      </if>
-
-      <if(listNodes.length)>
-        <div class="row">
-          <div class=`${block}__col-ad`>
-            <endeavor-gam-ad-unit-define-display ...adListInput aliases=adAliases />
-          </div>
-
-          <div class=`${block}__col-list`>
-            <endeavor-item-list flush=true card=true items=listNodes>
-              <@item|{ item }|>
                 <endeavor-content-block-item
-                  content=item
-                  image-position="left"
-                  image-options={ w: 176, h: 99, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
-                  image-width=176
-                  image-height=99
+                  content=content
+                  image-modifiers=["fluid", "21by9"]
+                  image-options={ w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0.5, fpY: 0.5 }
+                  image-position="top"
+                  modifiers=["card"]
                 />
-              </@item>
-            </endeavor-item-list>
+              </div>
+              <if(index === 1 || index === 6)>
+                <div class=`${block}__col`>
+                  <endeavor-gam-ad-unit-define-display ...adCardInput aliases=adAliases />
+                </div>
+              </if>
+            </for>
           </div>
-        </div>
-      </if>
-    </div>
+        </if>
 
-    <endeavor-load-more-button
-      append-to=".container-fluid-max"
-      block-name=block
-      label="Load More Content"
-      max-pages=loadMore.maxPages
-      page-number=pageNumber
-      provide=provide
-      show=hasNextPage
-    />
+        <if(listNodes.length)>
+          <div class="row">
+            <div class=`${block}__col-ad`>
+              <endeavor-gam-ad-unit-define-display ...adListInput aliases=adAliases />
+            </div>
+
+            <div class=`${block}__col-list`>
+              <endeavor-item-list flush=true card=true items=listNodes>
+                <@item|{ item }|>
+                  <endeavor-content-block-item
+                    content=item
+                    image-position="left"
+                    image-options={ w: 176, h: 99, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
+                    image-width=176
+                    image-height=99
+                  />
+                </@item>
+              </endeavor-item-list>
+            </div>
+          </div>
+        </if>
+      </div>
+
+      <endeavor-load-more-button
+        append-to=".container-fluid-max"
+        block-name=block
+        label="Load More Content"
+        max-pages=loadMore.maxPages
+        page-number=pageNumber
+        provide=provide
+        show=hasNextPage
+      />
+    </endeavor-page-section>
   </if>
 </cms-query-magazine-scheduled-content>

--- a/packages/common/components/content/blocks/query-load-more-list.marko
+++ b/packages/common/components/content/blocks/query-load-more-list.marko
@@ -42,52 +42,54 @@ $ const imageOptions = { w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0
 <div class=`${block} mb-block`>
   <cms-query-website-scheduled-content|{ nodes, pageInfo }| ...query>
     <if(nodes.length)>
-      <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
-      <div class="row">
-        <div class="col-lg-8">
-          <endeavor-item-list flush=true card=true items=nodes>
-            <@item|{ item }|>
-              <endeavor-content-block-item
-                content=item
-                image-position="left"
-                image-options={ w: 120, h: 120, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
-                image-width=75
-                image-height=75
-                with-image=true
-              />
-            </@item>
-          </endeavor-item-list>
+      <endeavor-page-section>
+        <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
+        <div class="row">
+          <div class="col-lg-8">
+            <endeavor-item-list flush=true card=true items=nodes>
+              <@item|{ item }|>
+                <endeavor-content-block-item
+                  content=item
+                  image-position="left"
+                  image-options={ w: 120, h: 120, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
+                  image-width=75
+                  image-height=75
+                  with-image=true
+                />
+              </@item>
+            </endeavor-item-list>
+          </div>
+          <div class="col-lg-4 ad-rail">
+            <endeavor-gam-ad-unit-define-display ...adList1Input />
+            <endeavor-gam-ad-unit-define-display ...adList2Input />
+          </div>
         </div>
-        <div class="col-lg-4 ad-rail">
-          <endeavor-gam-ad-unit-define-display ...adList1Input />
-          <endeavor-gam-ad-unit-define-display ...adList2Input />
-        </div>
-      </div>
 
-      $ const { endCursor, hasNextPage } = pageInfo;
-      $ delete query.skip;
-      $ delete query.queryFragment;
-      $ delete query.renderBody;
-      $ query.after = endCursor;
-      $ const provide = {
-        ...input,
-        query,
-        ads: {
-          aliases: adAliases,
-          list1: adList1Input,
-          list2: adList2Input,
-        },
-      };
+        $ const { endCursor, hasNextPage } = pageInfo;
+        $ delete query.skip;
+        $ delete query.queryFragment;
+        $ delete query.renderBody;
+        $ query.after = endCursor;
+        $ const provide = {
+          ...input,
+          query,
+          ads: {
+            aliases: adAliases,
+            list1: adList1Input,
+            list2: adList2Input,
+          },
+        };
 
-      <endeavor-load-more-button
-        append-to=".container-fluid-max"
-        block-name=block
-        label="Load More Content"
-        max-pages=loadMore.maxPages
-        page-number=pageNumber
-        provide=provide
-        show=hasNextPage
-      />
+        <endeavor-load-more-button
+          append-to=".container-fluid-max"
+          block-name=block
+          label="Load More Content"
+          max-pages=loadMore.maxPages
+          page-number=pageNumber
+          provide=provide
+          show=hasNextPage
+        />
+      </endeavor-page-section>
     </if>
   </cms-query-website-scheduled-content>
 </div>

--- a/packages/common/components/content/blocks/query-load-more-related.marko
+++ b/packages/common/components/content/blocks/query-load-more-related.marko
@@ -35,79 +35,81 @@ $ const imageOptions = { w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0
   $ const cardNodes = asArray(nodes.slice(0, 10));
   $ const listNodes = asArray(nodes.slice(10));
   <if(cardNodes.length || listNodes.length)>
-    <if(input.header && pageNumber === 1)>
-      <endeavor-load-more-header>
-        ${input.header}
-      </endeavor-load-more-header>
-    </if>
-    <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
-    <div class=block>
-      <if(cardNodes.length)>
-        <div class="row">
-          <for|content, index| of=cardNodes>
-            <div class=`${block}__col`>
-              <endeavor-content-block-item
-                content=content
-                image-modifiers=["fluid", "21by9"]
-                image-options=imageOptions
-                image-position="top"
-                modifiers=["card"]
-              />
-            </div>
-            <if(index === 1 || index === 6)>
+    <endeavor-page-section>
+      <if(input.header && pageNumber === 1)>
+        <endeavor-load-more-header>
+          ${input.header}
+        </endeavor-load-more-header>
+      </if>
+      <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
+      <div class=block>
+        <if(cardNodes.length)>
+          <div class="row">
+            <for|content, index| of=cardNodes>
               <div class=`${block}__col`>
-                <endeavor-gam-ad-unit-define-display ...adCardInput aliases=adAliases />
-              </div>
-            </if>
-          </for>
-        </div>
-      </if>
-
-      <if(listNodes.length)>
-        <div class="row">
-          <div class=`${block}__col-ad`>
-            <endeavor-gam-ad-unit-define-display ...adListInput aliases=adAliases />
-          </div>
-
-          <div class=`${block}__col-list`>
-            <endeavor-item-list flush=true card=true items=listNodes>
-              <@item|{ item }|>
                 <endeavor-content-block-item
-                  content=item
-                  image-position="left"
-                  image-options={ w: 176, h: 99, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
-                  image-width=176
-                  image-height=99
+                  content=content
+                  image-modifiers=["fluid", "21by9"]
+                  image-options=imageOptions
+                  image-position="top"
+                  modifiers=["card"]
                 />
-              </@item>
-            </endeavor-item-list>
+              </div>
+              <if(index === 1 || index === 6)>
+                <div class=`${block}__col`>
+                  <endeavor-gam-ad-unit-define-display ...adCardInput aliases=adAliases />
+                </div>
+              </if>
+            </for>
           </div>
-        </div>
-      </if>
-    </div>
-    $ const { endCursor, hasNextPage } = pageInfo;
-    $ delete query.skip;
-    $ delete query.queryFragment;
-    $ delete query.renderBody;
-    $ query.after = endCursor;
-    $ const provide = {
-      ...input,
-      query,
-      ads: {
-        aliases: adAliases,
-        card: adCardInput,
-        list: adListInput,
-      },
-    };
+        </if>
 
-    <endeavor-load-more-button
-      append-to=".container-fluid-max"
-      block-name="content-query-load-more-related"
-      label="Load More Content"
-      max-pages=loadMore.maxPages
-      page-number=pageNumber
-      provide=provide
-      show=hasNextPage
-    />
+        <if(listNodes.length)>
+          <div class="row">
+            <div class=`${block}__col-ad`>
+              <endeavor-gam-ad-unit-define-display ...adListInput aliases=adAliases />
+            </div>
+
+            <div class=`${block}__col-list`>
+              <endeavor-item-list flush=true card=true items=listNodes>
+                <@item|{ item }|>
+                  <endeavor-content-block-item
+                    content=item
+                    image-position="left"
+                    image-options={ w: 176, h: 99, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
+                    image-width=176
+                    image-height=99
+                  />
+                </@item>
+              </endeavor-item-list>
+            </div>
+          </div>
+        </if>
+      </div>
+      $ const { endCursor, hasNextPage } = pageInfo;
+      $ delete query.skip;
+      $ delete query.queryFragment;
+      $ delete query.renderBody;
+      $ query.after = endCursor;
+      $ const provide = {
+        ...input,
+        query,
+        ads: {
+          aliases: adAliases,
+          card: adCardInput,
+          list: adListInput,
+        },
+      };
+
+      <endeavor-load-more-button
+        append-to=".container-fluid-max"
+        block-name="content-query-load-more-related"
+        label="Load More Content"
+        max-pages=loadMore.maxPages
+        page-number=pageNumber
+        provide=provide
+        show=hasNextPage
+      />
+    </endeavor-page-section>
   </if>
 </cms-query-related-published-content>

--- a/packages/common/components/content/blocks/query-load-more.marko
+++ b/packages/common/components/content/blocks/query-load-more.marko
@@ -36,85 +36,87 @@ $ const imageOptions = { w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0
   $ const cardNodes = asArray(nodes.slice(0, 10));
   $ const listNodes = asArray(nodes.slice(10));
   <if(cardNodes.length || listNodes.length)>
-    <if(input.header && pageNumber === 1)>
-      <endeavor-load-more-header>
-        ${input.header}
-      </endeavor-load-more-header>
-    </if>
-    <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
-    <div class=block>
-      <if(cardNodes.length)>
-        <div class="row">
-          <for|content, index| of=cardNodes>
-            <div class=`${block}__col`>
-              <endeavor-content-nativex-item
-                placement=nativeX.placement
-                aliases=nativeX.aliases
-                index=nativeX.index
-                current-index=index
-                item={
-                  content,
-                  imageModifiers: ["fluid", "21by9"],
-                  imageOptions,
-                  imagePosition: "top",
-                  modifiers: ["card"]
-                }
-              />
-            </div>
-            <if(index === 1 || index === 6)>
+    <endeavor-page-section>
+      <if(input.header && pageNumber === 1)>
+        <endeavor-load-more-header>
+          ${input.header}
+        </endeavor-load-more-header>
+      </if>
+      <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
+      <div class=block>
+        <if(cardNodes.length)>
+          <div class="row">
+            <for|content, index| of=cardNodes>
               <div class=`${block}__col`>
-                <endeavor-gam-ad-unit-define-display ...adCardInput aliases=adAliases />
-              </div>
-            </if>
-          </for>
-        </div>
-      </if>
-
-      <if(listNodes.length)>
-        <div class="row">
-          <div class=`${block}__col-ad`>
-            <endeavor-gam-ad-unit-define-display ...adListInput aliases=adAliases />
-          </div>
-
-          <div class=`${block}__col-list`>
-            <endeavor-item-list flush=true card=true items=listNodes>
-              <@item|{ item }|>
-                <endeavor-content-block-item
-                  content=item
-                  image-position="right"
-                  image-options={ w: 120, h: 120, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
-                  image-width=75
-                  image-height=75
+                <endeavor-content-nativex-item
+                  placement=nativeX.placement
+                  aliases=nativeX.aliases
+                  index=nativeX.index
+                  current-index=index
+                  item={
+                    content,
+                    imageModifiers: ["fluid", "21by9"],
+                    imageOptions,
+                    imagePosition: "top",
+                    modifiers: ["card"]
+                  }
                 />
-              </@item>
-            </endeavor-item-list>
+              </div>
+              <if(index === 1 || index === 6)>
+                <div class=`${block}__col`>
+                  <endeavor-gam-ad-unit-define-display ...adCardInput aliases=adAliases />
+                </div>
+              </if>
+            </for>
           </div>
-        </div>
-      </if>
-    </div>
-    $ const { endCursor, hasNextPage } = pageInfo;
-    $ delete query.skip;
-    $ delete query.queryFragment;
-    $ delete query.renderBody;
-    $ query.after = endCursor;
-    $ const provide = {
-      ...input,
-      query,
-      ads: {
-        aliases: adAliases,
-        card: adCardInput,
-        list: adListInput,
-      },
-    };
+        </if>
 
-    <endeavor-load-more-button
-      append-to=".container-fluid-max"
-      block-name=block
-      label="Load More Content"
-      max-pages=loadMore.maxPages
-      page-number=pageNumber
-      provide=provide
-      show=hasNextPage
-    />
+        <if(listNodes.length)>
+          <div class="row">
+            <div class=`${block}__col-ad`>
+              <endeavor-gam-ad-unit-define-display ...adListInput aliases=adAliases />
+            </div>
+
+            <div class=`${block}__col-list`>
+              <endeavor-item-list flush=true card=true items=listNodes>
+                <@item|{ item }|>
+                  <endeavor-content-block-item
+                    content=item
+                    image-position="right"
+                    image-options={ w: 120, h: 120, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
+                    image-width=75
+                    image-height=75
+                  />
+                </@item>
+              </endeavor-item-list>
+            </div>
+          </div>
+        </if>
+      </div>
+      $ const { endCursor, hasNextPage } = pageInfo;
+      $ delete query.skip;
+      $ delete query.queryFragment;
+      $ delete query.renderBody;
+      $ query.after = endCursor;
+      $ const provide = {
+        ...input,
+        query,
+        ads: {
+          aliases: adAliases,
+          card: adCardInput,
+          list: adListInput,
+        },
+      };
+
+      <endeavor-load-more-button
+        append-to=".container-fluid-max"
+        block-name=block
+        label="Load More Content"
+        max-pages=loadMore.maxPages
+        page-number=pageNumber
+        provide=provide
+        show=hasNextPage
+      />
+    </endeavor-page-section>
   </if>
 </cms-query-website-scheduled-content>

--- a/packages/common/components/magazine/blocks/query-active-issues.marko
+++ b/packages/common/components/magazine/blocks/query-active-issues.marko
@@ -35,33 +35,36 @@ $ const adCardInput = {
     pageNumber,
     ads: input.ads,
   };
-
-  <div class=block>
-    <div class="row">
-      <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
-      <for|issue, index| of=nodes>
-        <div class=`${block}__col`>
-          <endeavor-magazine-issue-item
-            issue=issue
-            image-modifiers=["fluid", "3by4"]
-            image-options={ w: 630, h: 840, fit: "crop", crop: "focalpoint", fpX: 0.5, fpY: 0.5 }
-            image-position="top"
-            modifiers=["card"]
-            with-header=false
-            with-footer=false
-          />
+  <if(nodes.length)>
+    <endeavor-page-section>
+      <div class=block>
+        <div class="row">
+          <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
+          <for|issue, index| of=nodes>
+            <div class=`${block}__col`>
+              <endeavor-magazine-issue-item
+                issue=issue
+                image-modifiers=["fluid", "3by4"]
+                image-options={ w: 630, h: 840, fit: "crop", crop: "focalpoint", fpX: 0.5, fpY: 0.5 }
+                image-position="top"
+                modifiers=["card"]
+                with-header=false
+                with-footer=false
+              />
+            </div>
+          </for>
         </div>
-      </for>
-    </div>
-  </div>
+      </div>
 
-  <endeavor-load-more-button
-    append-to=".container-fluid-max"
-    block-name=block
-    label="Load More Issues"
-    max-pages=loadMore.maxPages
-    page-number=pageNumber
-    provide=provide
-    show=hasNextPage
-  />
+      <endeavor-load-more-button
+        append-to=".container-fluid-max"
+        block-name=block
+        label="Load More Issues"
+        max-pages=loadMore.maxPages
+        page-number=pageNumber
+        provide=provide
+        show=hasNextPage
+      />
+    </endeavor-page-section>
+  </if>
 </cms-query-magazine-active-issues>

--- a/packages/common/components/page/marko.json
+++ b/packages/common/components/page/marko.json
@@ -46,6 +46,9 @@
           "w": 352, "h": 198, "fit": "crop", "crop": "focalpoint", "fpX": 0.5, "fpY": 0.5
         }
       }
+    },
+    "endeavor-page-section": {
+      "template": "./section.marko"
     }
   }
 }

--- a/packages/common/components/page/section.marko
+++ b/packages/common/components/page/section.marko
@@ -1,0 +1,5 @@
+<div class="page-section">
+  <div class="page-section__contents">
+    <${input.renderBody} />
+  </div>
+</div>

--- a/packages/themes/default/layouts/content.marko
+++ b/packages/themes/default/layouts/content.marko
@@ -18,7 +18,9 @@ $ const initNativeX = input.initNativeX == null ? true : input.initNativeX;
   <div class="container-fluid-max">
     <${input.aboveContainer} />
     <cms-page-container for="content" data=content>
-      <${input.renderBody} />
+      <endeavor-page-section>
+        <${input.renderBody} />
+      </endeavor-page-section>
     </cms-page-container>
     <${input.belowContainer} />
   </div>

--- a/packages/themes/default/layouts/dynamic-page.marko
+++ b/packages/themes/default/layouts/dynamic-page.marko
@@ -13,7 +13,9 @@ $ const page = getAsObject(input, 'page');
   <div class="container-fluid-max">
     <${input.aboveContainer} />
     <cms-page-container for="dynamic-page" data=page>
-      <${input.renderBody} />
+      <endeavor-page-section>
+        <${input.renderBody} />
+      </endeavor-page-section>
     </cms-page-container>
     <${input.belowContainer} />
   </div>

--- a/packages/themes/default/layouts/magazine-issue.marko
+++ b/packages/themes/default/layouts/magazine-issue.marko
@@ -13,7 +13,9 @@ $ const issue = getAsObject(input, 'issue');
   <div class="container-fluid-max">
     <${input.aboveContainer} />
     <cms-page-container for="magazine-issue" data=issue>
-      <${input.renderBody} />
+      <endeavor-page-section>
+        <${input.renderBody} />
+      </endeavor-page-section>
     </cms-page-container>
     <${input.belowContainer} />
   </div>

--- a/packages/themes/default/layouts/magazine-publication.marko
+++ b/packages/themes/default/layouts/magazine-publication.marko
@@ -13,7 +13,9 @@ $ const publication = getAsObject(input, 'publication');
   <div class="container-fluid-max">
     <${input.aboveContainer} />
     <cms-page-container for="magazine-publication" data=publication>
-      <${input.renderBody} />
+      <endeavor-page-section>
+        <${input.renderBody} />
+      </endeavor-page-section>
     </cms-page-container>
     <${input.belowContainer} />
   </div>

--- a/packages/themes/default/layouts/magazine.marko
+++ b/packages/themes/default/layouts/magazine.marko
@@ -13,7 +13,9 @@ $ const description = site.get('magazines.description');
   <div class="container-fluid-max">
     <${input.aboveContainer} />
     <cms-page-container for="magazine">
-      <${input.renderBody} />
+      <endeavor-page-section>
+        <${input.renderBody} />
+      </endeavor-page-section>
     </cms-page-container>
     <${input.belowContainer} />
   </div>

--- a/packages/themes/default/layouts/published-content.marko
+++ b/packages/themes/default/layouts/published-content.marko
@@ -14,7 +14,9 @@ $ const page = getAsObject(input, 'page');
   <div class="container-fluid-max">
     <${input.aboveContainer} />
     <cms-page-container for="published-content">
-      <${input.renderBody} />
+      <endeavor-page-section>
+        <${input.renderBody} />
+      </endeavor-page-section>
     </cms-page-container>
     <${input.belowContainer} />
   </div>

--- a/packages/themes/default/layouts/search.marko
+++ b/packages/themes/default/layouts/search.marko
@@ -11,7 +11,9 @@ $ const { site } = out.global;
   <div class="container-fluid-max">
     <${input.aboveContainer} />
     <cms-page-container for="search">
-      <${input.renderBody} />
+      <endeavor-page-section>
+        <${input.renderBody} />
+      </endeavor-page-section>
     </cms-page-container>
     <${input.belowContainer} />
   </div>

--- a/packages/themes/default/layouts/subscribe.marko
+++ b/packages/themes/default/layouts/subscribe.marko
@@ -11,7 +11,9 @@ $ const { site } = out.global;
   <div class="container-fluid-max">
     <${input.aboveContainer} />
     <cms-page-container for="subscribe">
-      <${input.renderBody} />
+      <endeavor-page-section>
+        <${input.renderBody} />
+      </endeavor-page-section>
     </cms-page-container>
     <${input.belowContainer} />
   </div>

--- a/packages/themes/default/layouts/user.marko
+++ b/packages/themes/default/layouts/user.marko
@@ -12,7 +12,9 @@ $ const type = `user-${input.for}`;
   <div class="container-fluid-max">
     <${input.aboveContainer} />
     <cms-page-container for=type>
-      <${input.renderBody} />
+      <endeavor-page-section>
+        <${input.renderBody} />
+      </endeavor-page-section>
     </cms-page-container>
     <${input.belowContainer} />
   </div>

--- a/packages/themes/default/layouts/website-section.marko
+++ b/packages/themes/default/layouts/website-section.marko
@@ -19,7 +19,9 @@ $ const initNativeX = input.initNativeX == null ? true : input.initNativeX;
   <div class="container-fluid-max">
     <${input.aboveContainer} />
     <cms-page-container for="website-section" data=section>
-      <${input.renderBody} />
+      <endeavor-page-section>
+        <${input.renderBody} />
+      </endeavor-page-section>
     </cms-page-container>
     <${input.belowContainer} />
   </div>

--- a/packages/themes/default/styles/_mixins.scss
+++ b/packages/themes/default/styles/_mixins.scss
@@ -11,6 +11,17 @@
   }
 }
 
+
+@mixin theme-line-height-crop($line-height) {
+  &::before {
+    display: block;
+    width: 0;
+    height: 0;
+    margin-top: calc((1 - #{$line-height}) * .5em);
+    content: "";
+  }
+}
+
 @mixin theme-apply-fonts(
   $font-family: $font-family-sans-serif,
   $font-size-sm: $font-size-sm,

--- a/packages/themes/default/styles/theme/_page.scss
+++ b/packages/themes/default/styles/theme/_page.scss
@@ -96,6 +96,16 @@
   }
 }
 
+.page-section {
+  @include make-row();
+  background-color: $body-bg;
+  &__contents {
+    @include make-col-ready();
+    @include make-col(12);
+    padding-top: $grid-gutter-width / 2;
+  }
+}
+
 .content-page,
 .default-page,
 .dynamic-page {

--- a/sites/bizbash/components/load-more/components/wrapper.marko
+++ b/sites/bizbash/components/load-more/components/wrapper.marko
@@ -34,32 +34,34 @@ $ const QueryComponent = queries[type];
 
 <${QueryComponent}|{ nodes, pageInfo }| ...query>
   <if(nodes.length)>
-    <if(input.header && pageNumber === 1)>
-      <endeavor-load-more-header>
-        ${input.header}
-      </endeavor-load-more-header>
-    </if>
-    <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
+    <endeavor-page-section>
+      <if(input.header && pageNumber === 1)>
+        <endeavor-load-more-header>
+          ${input.header}
+        </endeavor-load-more-header>
+      </if>
+      <cms-gtm-track-inview-event name="page_load" vars={ page_number: pageNumber + 1 } />
 
-    <${input.renderBody} nodes=nodes page-info=pageInfo />
+      <${input.renderBody} nodes=nodes page-info=pageInfo />
 
-    $ const { endCursor, hasNextPage } = pageInfo;
-    $ delete query.skip;
-    $ delete query.queryFragment;
-    $ delete query.renderBody;
-    $ const provide = {
-      ...input,
-      query: { ...query, after: endCursor },
-    };
+      $ const { endCursor, hasNextPage } = pageInfo;
+      $ delete query.skip;
+      $ delete query.queryFragment;
+      $ delete query.renderBody;
+      $ const provide = {
+        ...input,
+        query: { ...query, after: endCursor },
+      };
 
-    <endeavor-load-more-button
-      append-to=(input.appendTo || '.container-fluid-max')
-      block-name="load-more"
-      label="Load More Content"
-      max-pages=input.maxPages
-      page-number=pageNumber
-      provide=provide
-      show=hasNextPage
-    />
+      <endeavor-load-more-button
+        append-to=(input.appendTo || '.container-fluid-max')
+        block-name="load-more"
+        label="Load More Content"
+        max-pages=input.maxPages
+        page-number=pageNumber
+        provide=provide
+        show=hasNextPage
+      />
+    </endeavor-page-section>
   </if>
 </>

--- a/sites/bizbash/server/styles/index.scss
+++ b/sites/bizbash/server/styles/index.scss
@@ -249,15 +249,12 @@ body {
   }
 }
 
-.website-scheduled-content-hero {
-  &__list {
-    margin-top: -6px;
-  }
-}
-
 .item {
   $self: &;
   &__title {
+    // @todo more to core?
+    @include theme-line-height-crop($theme-item-title-line-height);
+
     &--card-deck {
       $title-font-size: 21px;
       $title-font-size-sm: 16px;
@@ -307,7 +304,7 @@ body {
   &--image-left {
     #{ $self } {
       &__image {
-        margin-top: 6px;
+        margin-top: 0;
       }
     }
   }
@@ -315,7 +312,7 @@ body {
   &--image-right {
     #{ $self } {
       &__image {
-        margin-top: 6px;
+        margin-top: 0;
       }
     }
   }
@@ -451,6 +448,9 @@ body {
   // @todo Add to core
   min-height: auto;
   &__header {
+    // @todo more to core?
+    @include theme-line-height-crop(1.5);
+    display: inline-block;
     padding: $theme-item-padding;
     padding-bottom: 0;
   }

--- a/sites/bizbash/server/templates/index.marko
+++ b/sites/bizbash/server/templates/index.marko
@@ -26,7 +26,7 @@ $ const adSlots = {
     <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
   </@above-container>
 
-  <website-scheduled-content-hero query={ sectionId: section.id, optionId: 40105, requiresImage: true, queryFragment: contentListFragment }>
+  <website-scheduled-content-hero query={ sectionId: section.id, optionId: 40105, requiresImage: true, queryFragment: contentListFragment } item-list={ modifiers: ["height-100"] }>
     <@card-item|{ node }|>
       <bizbash-hero-card content=node />
     </@card-item>

--- a/sites/bizbash/server/templates/website-section/gathergeeks.marko
+++ b/sites/bizbash/server/templates/website-section/gathergeeks.marko
@@ -1,6 +1,7 @@
 import { get, getAsObject } from '@base-cms/object-path';
 import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
 import hierarchyAliases from '@endeavorb2b/base-website-common/utils/website-section/hierarchy-aliases';
+import contentListFragment from '../../api/fragments/content-list';
 
 $ const { site } = out.global;
 $ const section = getAsObject(data, 'section');
@@ -36,10 +37,14 @@ $ const adSlots = {
     </div>
   </div>
 
+  <cms-query-website-scheduled-content|{ nodes }| section-id=section.id limit=25 requires-image=true query-fragment=contentListFragment>
+    <bizbash-load-more-content-layout name="list-large" nodes=nodes layout={ aliases } />
+  </cms-query-website-scheduled-content>
+
   <@below-container>
     <bizbash-load-more
       type="website-scheduled-content"
-      query={ sectionId: section.id, limit: 25 }
+      query={ sectionId: section.id, limit: 25, skip: 25 }
       layout={ name: "list-large", aliases }
     />
   </@below-container>

--- a/sites/bizbash/server/templates/website-section/index.marko
+++ b/sites/bizbash/server/templates/website-section/index.marko
@@ -1,6 +1,7 @@
 import { getAsObject, getAsArray, get } from '@base-cms/object-path';
 import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
 import hierarchyAliases from '@endeavorb2b/base-website-common/utils/website-section/hierarchy-aliases';
+import contentListFragment from '../../api/fragments/content-list';
 
 $ const { site } = out.global;
 $ const section = getAsObject(data, 'section');
@@ -37,10 +38,14 @@ $ const adSlots = {
     </div>
   </div>
 
+  <cms-query-website-scheduled-content|{ nodes }| section-id=section.id limit=14 requires-image=true query-fragment=contentListFragment>
+    <bizbash-load-more-content-layout nodes=nodes layout={ aliases } />
+  </cms-query-website-scheduled-content>
+
   <@below-container>
     <bizbash-load-more
       type="website-scheduled-content"
-      query={ sectionId: section.id }
+      query={ sectionId: section.id, skip: 14 }
       layout={ aliases }
     />
   </@below-container>

--- a/sites/bizbash/server/templates/website-section/industry-buzz.marko
+++ b/sites/bizbash/server/templates/website-section/industry-buzz.marko
@@ -1,6 +1,7 @@
 import { get, getAsObject } from '@base-cms/object-path';
 import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
 import hierarchyAliases from '@endeavorb2b/base-website-common/utils/website-section/hierarchy-aliases';
+import contentListFragment from '../../api/fragments/content-list';
 
 $ const { site } = out.global;
 $ const section = getAsObject(data, 'section');
@@ -38,10 +39,14 @@ $ const adSlots = {
     </div>
   </div>
 
+  <cms-query-website-scheduled-content|{ nodes }| section-id=section.id limit=18 query-fragment=contentListFragment>
+    <bizbash-load-more-content-layout name="card-item-deck" nodes=nodes layout={ aliases } />
+  </cms-query-website-scheduled-content>
+
   <@below-container>
     <bizbash-load-more
       type="website-scheduled-content"
-      query={ sectionId: section.id, limit: 18, requiresImage: false }
+      query={ sectionId: section.id, limit: 18, skip: 18, requiresImage: false }
       layout={ name: "card-item-deck", aliases }
     />
   </@below-container>


### PR DESCRIPTION
Ensures that page contents and "load more" pages are wrapped. This allows wallpapers/reskins to display properly. By default, no visible changes will be present on any sites, unless a reskin ad is fired.

Example (pink background was added for emphasis and is _not_ included in this PR):
![image](https://user-images.githubusercontent.com/3289485/63524897-63e28580-c4c2-11e9-8dab-8c9e5c125c74.png)
![image](https://user-images.githubusercontent.com/3289485/63524912-6a70fd00-c4c2-11e9-9cb1-c09ca8bee9db.png)
![image](https://user-images.githubusercontent.com/3289485/63524930-7230a180-c4c2-11e9-9052-718832f1f95d.png)
![image](https://user-images.githubusercontent.com/3289485/63524941-76f55580-c4c2-11e9-926e-4fe5ab450ab8.png)
