### PR TITLE
CS2783-LFW: added “Photonics Business” topic

### DIFF
--- a/sites/laserfocusworld/config/site.js
+++ b/sites/laserfocusworld/config/site.js
@@ -32,6 +32,7 @@ module.exports = {
         { href: '/fiber-optics', label: 'Fiber Optics' },
         { href: '/software-accessories', label: 'Software & Accessories' },
         { href: '/test-measurement', label: 'Test & Measurement' },
+        { href: '/photonics-business', label: 'Photonics Business' }
       ],
     },
     secondary: {
@@ -65,6 +66,7 @@ module.exports = {
           { href: '/fiber-optics', label: 'Fiber Optics' },
           { href: '/software-accessories', label: 'Software & Accessories' },
           { href: '/test-measurement', label: 'Test & Measurement' },
+          { href: '/photonics-business', label: 'Photonics Business' }
         ],
       },
       resources: {

--- a/sites/laserfocusworld/config/site.js
+++ b/sites/laserfocusworld/config/site.js
@@ -32,7 +32,7 @@ module.exports = {
         { href: '/fiber-optics', label: 'Fiber Optics' },
         { href: '/software-accessories', label: 'Software & Accessories' },
         { href: '/test-measurement', label: 'Test & Measurement' },
-        { href: '/photonics-business', label: 'Photonics Business' }
+        { href: '/photonics-business', label: 'Photonics Business' },
       ],
     },
     secondary: {
@@ -66,7 +66,7 @@ module.exports = {
           { href: '/fiber-optics', label: 'Fiber Optics' },
           { href: '/software-accessories', label: 'Software & Accessories' },
           { href: '/test-measurement', label: 'Test & Measurement' },
-          { href: '/photonics-business', label: 'Photonics Business' }
+          { href: '/photonics-business', label: 'Photonics Business' },
         ],
       },
       resources: {

--- a/sites/laserfocusworld/server/styles/index.scss
+++ b/sites/laserfocusworld/server/styles/index.scss
@@ -14,7 +14,7 @@ $theme-site-header-breakpoints: (
   hide-primary: 832px,
   hide-secondary: 906px,
   small-logo: 1015px,
-  small-text-primary: 932px,
+  small-text-primary: 1093px,
   small-text-secondary: 1105px
 );
 

--- a/sites/laserfocusworld/server/templates/index.marko
+++ b/sites/laserfocusworld/server/templates/index.marko
@@ -146,9 +146,8 @@ $ const adSlots = {
     <div class="col-lg-4 mb-block">
       <endeavor-content-query-section-list
         limit=3
-        skip=4
-        section-alias=section.alias
-        header={ title: `More from ${out.global.config.siteName()}` }
+        section-alias="photonics-business"
+        header={ title: "Photonics Business", href: "/photonics-business" }
       />
     </div>
     <div class="col-lg-4 mb-block">


### PR DESCRIPTION
Pre-req:
- Added a new website section called “Photonics Business” with the alias “photonics-business” on Base
- Requested Carrie schedule articles to the new topic for verification

Code changes:
- Added “Photonics Business” to the main navigation and the topics section of the hamburger nav
- Replaced the “More” content block on the homepage with the new “Photonics Business” block

Hamburger Before:
<img width="279" alt="Screen Shot 2019-08-23 at 11 48 28 AM" src="https://user-images.githubusercontent.com/6343242/63609087-07539900-c59c-11e9-9e14-021bdc89f296.png">

Main Nav Before:
<img width="1188" alt="Screen Shot 2019-08-23 at 11 48 08 AM" src="https://user-images.githubusercontent.com/6343242/63609088-07539900-c59c-11e9-8e35-0c40fb0e10d9.png">

Index Page Content Blocks Before:
<img width="1210" alt="Screen Shot 2019-08-23 at 11 47 48 AM" src="https://user-images.githubusercontent.com/6343242/63609089-07539900-c59c-11e9-84f8-696c5fc661f8.png">

Hamburger After:
<img width="269" alt="Screen Shot 2019-08-23 at 11 48 19 AM" src="https://user-images.githubusercontent.com/6343242/63609102-0f133d80-c59c-11e9-830d-fe0517c87f9f.png">

Main Nav After:
<img width="1200" alt="Screen Shot 2019-08-23 at 11 47 59 AM" src="https://user-images.githubusercontent.com/6343242/63609103-0fabd400-c59c-11e9-800a-6b80c73ec9a3.png">

Index Page Content Blocks After:
<img width="1196" alt="Screen Shot 2019-08-23 at 11 47 37 AM" src="https://user-images.githubusercontent.com/6343242/63609104-0fabd400-c59c-11e9-941b-c41e6e682ccc.png">
