### PR TITLE
Pass link attributes as-is from NativeX

### DIFF
--- a/packages/common/components/content/blocks/nativex-item.marko
+++ b/packages/common/components/content/blocks/nativex-item.marko
@@ -21,7 +21,6 @@ $ const itemInput = getAsObject(input, 'item');
     $ const hasAd = ads && ads.length && ads[0];
     <if(hasAd)>
       $ const ad = ads[0];
-      $ const linkAttrs = { target: "_blank", rel: "noopener", ...ad.attributes.link };
       <if(ad.hasCampaign)>
         <!-- Campaign found. Convert the ad to a "content object" and append tracking. -->
         <!-- Note: `image-options` are intentionally reset, as NX handles them directly (see L19) -->
@@ -29,7 +28,7 @@ $ const itemInput = getAsObject(input, 'item');
         <endeavor-content-block-item
           ...itemInput
           attrs=ad.attributes.container
-          content-link-attrs=linkAttrs
+          content-link-attrs=ad.attributes.lin
           content=content
           image-options={}
         />

--- a/packages/common/components/content/blocks/nativex-item.marko
+++ b/packages/common/components/content/blocks/nativex-item.marko
@@ -28,7 +28,7 @@ $ const itemInput = getAsObject(input, 'item');
         <endeavor-content-block-item
           ...itemInput
           attrs=ad.attributes.container
-          content-link-attrs=ad.attributes.lin
+          content-link-attrs=ad.attributes.link
           content=content
           image-options={}
         />

--- a/packages/native-x/components/site-render.marko
+++ b/packages/native-x/components/site-render.marko
@@ -20,14 +20,13 @@ $ const isEnabled = () => {
       $ const hasAd = ads && ads.length && ads[0];
       <if(hasAd)>
         $ const ad = ads[0];
-        $ const linkAttrs = { target: "_blank", rel: "noopener", ...ad.attributes.link };
         <if(ad.hasCampaign)>
            $ const campaign = convertAdToContent(ad);
            <${input.whenFound}
             ad=ad
             campaign=campaign
             container-attrs=ad.attributes.container
-            link-attrs=linkAttrs
+            link-attrs=ad.attributes.link
           />
         </if>
         <else>


### PR DESCRIPTION
Per cygnusb2b/fortnight-graph#181, pass the tracked link attributes as-is, which will include `rel="nofollow"` as well as `noopener` when applicable.