### PR TITLE
2914-OGJ: update to sign-in/form.vue

### DIFF
--- a/packages/identity-x/browser/components/sign-in/form.vue
+++ b/packages/identity-x/browser/components/sign-in/form.vue
@@ -15,8 +15,11 @@
       We just sent an email to <em>{{ user.email }}</em> with your one-time login link.
       To finish logging in, open the email message and click the link within.
     </p>
-    <!-- eslint-disable-next-line max-len -->
-    <p>Note: please check your spam/junk folders. If you do not receive this email, your firewall or ISP has likely blocked it. Please add noreply@identity-x.base-cms.io to your whitelist and try registering again.</p>
+    <p>
+      Note: please check your spam/junk folders.
+      If you do not receive this email, your firewall or ISP has likely blocked it.
+      Please add noreply@identity-x.base-cms.io to your whitelist and try registering again.
+    </p>
   </div>
   <div v-else-if="needsInput">
     <p>To complete this sign-on process, please fill out these remaining fields.</p>

--- a/packages/identity-x/browser/components/sign-in/form.vue
+++ b/packages/identity-x/browser/components/sign-in/form.vue
@@ -15,7 +15,8 @@
       We just sent an email to <em>{{ user.email }}</em> with your one-time login link.
       To finish logging in, open the email message and click the link within.
     </p>
-    <p>Note: please make sure you check your spam and or clutter/junk folders. If you do not receive this email, it means your Company firewall or ISP has blocked it. The email will be sent from: noreply@identity-x.base-cms.io Please add this domain to your safelist/whitelist and try registering again.</p>
+    <!-- eslint-disable-next-line max-len -->
+    <p>Note: please check your spam/junk folders. If you do not receive this email, your firewall or ISP has likely blocked it. Please add noreply@identity-x.base-cms.io to your whitelist and try registering again.</p>
   </div>
   <div v-else-if="needsInput">
     <p>To complete this sign-on process, please fill out these remaining fields.</p>

--- a/packages/identity-x/browser/components/sign-in/form.vue
+++ b/packages/identity-x/browser/components/sign-in/form.vue
@@ -15,7 +15,7 @@
       We just sent an email to <em>{{ user.email }}</em> with your one-time login link.
       To finish logging in, open the email message and click the link within.
     </p>
-    <p>Note: please make sure you check your spam and or clutter/junk folders.</p>
+    <p>Note: please make sure you check your spam and or clutter/junk folders. If you do not receive this email, it means your Company firewall or ISP has blocked it. The email will be sent from: noreply@identity-x.base-cms.io Please add this domain to your safelist/whitelist and try registering again.</p>
   </div>
   <div v-else-if="needsInput">
     <p>To complete this sign-on process, please fill out these remaining fields.</p>


### PR DESCRIPTION
Added disclaimer to the universal sign-in/form.vue to advice customers to check with their company’s IT if they do not receive the login/registration email.

https://southcomm.atlassian.net/projects/CS/queues/custom/11/CS-2914

**Before:**
<img width="1174" alt="Screen Shot 2019-09-03 at 9 38 27 AM" src="https://user-images.githubusercontent.com/6343242/64183158-0be73f80-ce2f-11e9-8ec6-58dff21407c1.png">

**After**
<img width="1175" alt="Screen Shot 2019-09-03 at 9 37 46 AM" src="https://user-images.githubusercontent.com/6343242/64183176-16a1d480-ce2f-11e9-90dd-1dc7207cb05c.png">

