### PR TITLE
Add teasers to load more cards and list

### DIFF
--- a/packages/common/components/content/blocks/query-load-more.marko
+++ b/packages/common/components/content/blocks/query-load-more.marko
@@ -6,7 +6,7 @@ $ const { site } = out.global;
 $ const pageNumber = input.pageNumber || 1;
 $ const block = 'content-query-load-more';
 $ const query = {
-  limit: 16,
+  limit: 14,
   ...input.query,
   queryFragment: contentListFragment,
   queryName: 'QueryLoadMore',
@@ -58,7 +58,8 @@ $ const imageOptions = { w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0
                     imageModifiers: ["fluid", "21by9"],
                     imageOptions,
                     imagePosition: "top",
-                    modifiers: ["card"]
+                    modifiers: ["card"],
+                    withTeaser: true,
                   }
                 />
               </div>
@@ -86,6 +87,7 @@ $ const imageOptions = { w: 630, h: 270, fit: "crop", crop: "focalpoint", fpX: 0
                     image-options={ w: 120, h: 120, fit: 'crop', crop: 'focalpoint', fpX: 0.5, fpY: 0.5 }
                     image-width=75
                     image-height=75
+                    with-teaser=true
                   />
                 </@item>
               </endeavor-item-list>

--- a/packages/themes/default/styles/_variables.scss
+++ b/packages/themes/default/styles/_variables.scss
@@ -319,8 +319,10 @@ $theme-item-description-font-family:          $theme-font-family-serif !default;
 $theme-item-description-font-size-sm:         16px !default;
 $theme-item-description-font-size:            17px !default;
 $theme-item-description-font-weight:          $font-weight-normal !default;
-$theme-item-description-line-height-sm:       get-line-height($theme-item-description-font-size-sm, 23px) !default;
-$theme-item-description-line-height:          get-line-height($theme-item-description-font-size, 25px) !default;
+$theme-item-description-line-height-sm-px:    23px !default;
+$theme-item-description-line-height-sm:       get-line-height($theme-item-description-font-size-sm, $theme-item-description-line-height-sm-px) !default;
+$theme-item-description-line-height-px:       25px !default;
+$theme-item-description-line-height:          get-line-height($theme-item-description-font-size, $theme-item-description-line-height-px) !default;
 
 $theme-item-description-margin:                $theme-item-element-margin !default;
 $theme-item-description-color:                 $body-color !default;

--- a/packages/themes/orion/styles/theme.scss
+++ b/packages/themes/orion/styles/theme.scss
@@ -13,6 +13,12 @@ $theme-font-family-page-title: "Cardo", "Georgia", "Cambria", "Times New Roman",
 
 $theme-card-header-letter-spacing: 1px !default;
 
+$theme-item-description-font-size-sm:       11px !default;
+$theme-item-description-font-size:          13px !default;
+$theme-item-description-max-lines:          4 !default;
+$theme-item-description-line-height-sm-px:  17px !default;
+$theme-item-description-line-height-px:     19px !default;
+
 @import "../../default/styles/theme";
 
 // Override classes here.


### PR DESCRIPTION
And reduces font size and line height for `orion` themed sites.

![image](https://user-images.githubusercontent.com/3289485/64257074-52e63b00-ceea-11e9-9d96-ebd0e2abc174.png)
![image](https://user-images.githubusercontent.com/3289485/64257090-58dc1c00-ceea-11e9-900e-59fc135138f5.png)

