### PR TITLE
CS2938 and CS2940 for EE

### DIFF
--- a/sites/evaluationengineering/server/templates/content/index.marko
+++ b/sites/evaluationengineering/server/templates/content/index.marko
@@ -37,7 +37,7 @@ $ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.t
 
     <div class="row">
       <div class="col-lg-8">
-        <endeavor-content-block-page-body content=content display-primary-image=displayPrimaryImage />
+        <endeavor-content-block-page-body content=content display-primary-image=false />
       </div>
 
       <aside class="col-lg-4">

--- a/sites/evaluationengineering/server/templates/index.marko
+++ b/sites/evaluationengineering/server/templates/index.marko
@@ -44,9 +44,9 @@ $ const adSlots = {
         <div class="col-lg-6 mb-block">
           <endeavor-content-query-section-list
             limit=4
-            section-alias="industries"
-            header={ title: "Industries", href: "/industries" }
-            native-x={ placement: 'list1', aliases: ['industries'], index: 3 }
+            section-alias="instrumentation"
+            header={ title: "Instrumentation", href: "/instrumentation" }
+            native-x={ placement: 'list1', aliases: ['instrumentation'], index: 3 }
           />
         </div>
       </div>
@@ -61,9 +61,9 @@ $ const adSlots = {
     <div class="col-lg-4 mb-block">
       <endeavor-content-query-section-list
         limit=4
-        section-alias="instrumentation"
-        header={ title: "Instrumentation", href: "/instrumentation" }
-        native-x={ placement: 'list1', aliases: ['instrumentation'], index: 3 }
+        section-alias="industries"
+        header={ title: "Industries", href: "/industries" }
+        native-x={ placement: 'list1', aliases: ['industries'], index: 3 }
       />
     </div>
     <div class="col-lg-4 mb-block">


### PR DESCRIPTION
Switched home blocks for "Instrumentation" and "Industries", per https://southcomm.atlassian.net/projects/CS/queues/custom/11/CS-2940

Before:
<img width="798" alt="Screen Shot 2019-09-04 at 11 41 20 AM" src="https://user-images.githubusercontent.com/6343242/64274563-39082080-cf09-11e9-8395-812b651a2206.png">

After:
<img width="795" alt="Screen Shot 2019-09-04 at 11 43 19 AM" src="https://user-images.githubusercontent.com/6343242/64274573-3dccd480-cf09-11e9-9638-2a7d7b64bc00.png">


Set primary image display to false, per https://southcomm.atlassian.net/projects/CS/queues/custom/11/CS-2938

Before:
<img width="506" alt="Screen Shot 2019-09-04 at 11 44 18 AM" src="https://user-images.githubusercontent.com/6343242/64274660-7076cd00-cf09-11e9-8a9a-4a153ae06031.png">

After:
<img width="522" alt="Screen Shot 2019-09-04 at 11 44 41 AM" src="https://user-images.githubusercontent.com/6343242/64274670-753b8100-cf09-11e9-8b06-1a7114ff5b9a.png">
