### PR TITLE
2962-CIM: added innovators channel to navs

### DIFF
--- a/sites/cablinginstall/config/ads.js
+++ b/sites/cablinginstall/config/ads.js
@@ -88,4 +88,12 @@ module.exports = {
     'load-more': { ...CONTENT, path: path('testing/load-more') },
     reskin: { ...RESKIN, path: path('testing/reskin') },
   },
+  innovators: {
+    lb1: { ...LB, path: path('innovators/lb1') },
+    lb2: { ...LB, path: path('innovators/lb2') },
+    rail1: { ...CONTENT, path: path('innovators/rail1') },
+    rail2: { ...CONTENT, path: path('innovators/rail2') },
+    'load-more': { ...CONTENT, path: path('innovators/load-more') },
+    reskin: { ...RESKIN, path: path('innovators/reskin') },
+  },
 };

--- a/sites/cablinginstall/config/site.js
+++ b/sites/cablinginstall/config/site.js
@@ -45,6 +45,7 @@ module.exports = {
         { href: '/webcasts', label: 'Webcasts' },
         { href: 'https://buyersguide.cablinginstall.com/', label: 'Buyer\'s Guide', target: '_blank' },
         { href: 'https://cablingawards.secure-platform.com/a', label: 'Awards', target: '_blank' },
+        { href: '/innovators', label: 'Innovators' },
       ],
     },
     footer: {
@@ -79,6 +80,7 @@ module.exports = {
           { href: '/webcasts', label: 'Webcasts' },
           { href: 'https://buyersguide.cablinginstall.com/', label: 'Buyer\'s Guide', target: '_blank' },
           { href: 'https://cablingawards.secure-platform.com/a', label: 'Awards', target: '_blank' },
+          { href: '/innovators', label: 'Innovators' },
         ],
       },
       userTools: {


### PR DESCRIPTION
Per https://southcomm.atlassian.net/projects/CS/queues/custom/11/CS-2962

Note addition of "Innovators" channel to the end of the secondary nav and the end of the Resources section of the hamburger nav.

Previous:
<img width="265" alt="Screen Shot 2019-09-09 at 5 30 06 PM" src="https://user-images.githubusercontent.com/6343242/64568166-140c1700-d328-11e9-8eb3-ea525905270f.png">
<img width="1217" alt="Screen Shot 2019-09-09 at 5 29 58 PM" src="https://user-images.githubusercontent.com/6343242/64568167-140c1700-d328-11e9-84db-b814401ff735.png">


New:
<img width="266" alt="Screen Shot 2019-09-09 at 5 29 46 PM" src="https://user-images.githubusercontent.com/6343242/64568175-1a01f800-d328-11e9-914b-04436a061cd2.png">
<img width="1228" alt="Screen Shot 2019-09-09 at 5 29 40 PM" src="https://user-images.githubusercontent.com/6343242/64568176-1a01f800-d328-11e9-83e7-cc41817fb5fc.png">
