### PR TITLE
CS2962-CIM: adjusted mobile settings for header

### DIFF
--- a/sites/cablinginstall/server/styles/index.scss
+++ b/sites/cablinginstall/server/styles/index.scss
@@ -13,10 +13,10 @@ $theme-site-navbar-logo-height: 50px;
 
 $theme-site-header-breakpoints: (
   hide-primary: 786px,
-  hide-secondary: 746px,
-  small-logo: 870px,
+  hide-secondary: 829px,
+  small-logo: 960px,
   small-text-primary: 880px,
-  small-text-secondary: 940px
+  small-text-secondary: 1035px
 );
 
 @import "../../node_modules/@endeavorb2b/base-website-themes/orion/styles/theme";


### PR DESCRIPTION
To provide room for the additional menu item: "Innovators" in the secondary nav