### PR TITLE
CS2980-Whitepaper: Button update

### DIFF
--- a/packages/themes/default/templates/whitepaper.marko
+++ b/packages/themes/default/templates/whitepaper.marko
@@ -39,9 +39,11 @@ $ const wrapClass = (surveyId) ? "row flex-lg-wrap-reverse flex-wrap-reverse" : 
             <cms-browser-component name="GatedDownloadWufoo" props={ formHash: surveyId, target, userName } />
           </else-if>
         </if>
-        <else-if(content.fileSrc !== 'https://media.baseplatform.io//undefined')>
+        <else-if(content.fileSrc)>
           <endeavor-content-block-primary-media content=content display-primary-image=true />
-          <endeavor-content-block-download-button content=content />
+          <if(content.fileSrc !== 'https://media.baseplatform.io//undefined')>
+            <endeavor-content-block-download-button content=content />
+          </if>
         </else-if>
       </aside>
     </div>


### PR DESCRIPTION
Set download button to not display if the file is undefined.

Primary image should still display, as long as a survey/form is not present

Change should only affect whitepapers which do NOT have a survey/gating set.

**Before:**
_Note -- the black button present within the text was manually added by the LW team._
<img width="1198" alt="Screen Shot 2019-09-11 at 3 59 18 PM" src="https://user-images.githubusercontent.com/6343242/64730379-35e2d680-d4ad-11e9-83bf-d3e23a38500e.png">

**After:**
<img width="1192" alt="Screen Shot 2019-09-11 at 3 53 08 PM" src="https://user-images.githubusercontent.com/6343242/64730393-3c714e00-d4ad-11e9-8d9b-8f3eff5b5f2f.png">
