### PR TITLE
CS2977-EE: updated homeblocks

### DIFF
--- a/sites/evaluationengineering/server/templates/index.marko
+++ b/sites/evaluationengineering/server/templates/index.marko
@@ -36,9 +36,8 @@ $ const adSlots = {
         <div class="col-lg-6 mb-block">
           <endeavor-content-query-section-list
             limit=4
-            section-alias="applications"
-            header={ title: "Applications", href: "/applications" }
-            native-x={ placement: 'list1', aliases: ['applications'], index: 3 }
+            section-alias="on-topic"
+            header={ title: "On Topic", href: "/on-topic" }
           />
         </div>
         <div class="col-lg-6 mb-block">
@@ -61,17 +60,17 @@ $ const adSlots = {
     <div class="col-lg-4 mb-block">
       <endeavor-content-query-section-list
         limit=4
-        section-alias="industries"
-        header={ title: "Industries", href: "/industries" }
-        native-x={ placement: 'list1', aliases: ['industries'], index: 3 }
+        section-alias="applications"
+        header={ title: "Applications", href: "/applications" }
+        native-x={ placement: 'list1', aliases: ['applications'], index: 3 }
       />
     </div>
     <div class="col-lg-4 mb-block">
       <endeavor-content-query-section-list
         limit=4
-        section-alias="test-issues-techniques"
-        header={ title: "Test Issues & Techniques", href: "/test-issues-techniques" }
-        native-x={ placement: 'list1', aliases: ['test-issues-techniques'], index: 3 }
+        section-alias="industries"
+        header={ title: "Industries", href: "/industries" }
+        native-x={ placement: 'list1', aliases: ['industries'], index: 3 }
       />
     </div>
     <div class="col-lg-4 mb-block">
@@ -88,6 +87,14 @@ $ const adSlots = {
     <div class="col-lg-4 mb-block">
       <endeavor-content-query-section-list
         limit=4
+        section-alias="test-issues-techniques"
+        header={ title: "Test Issues & Techniques", href: "/test-issues-techniques" }
+        native-x={ placement: 'list1', aliases: ['test-issues-techniques'], index: 3 }
+      />
+    </div>
+    <div class="col-lg-4 mb-block">
+      <endeavor-content-query-section-list
+        limit=4
         section-alias="ee-blogs"
         header={ title: "EE Blogs", href: "/ee-blogs" }
       />
@@ -99,6 +106,16 @@ $ const adSlots = {
         header={ title: "Online Exclusives", href: "/online-exclusives" }
       />
     </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-4 mb-block">
+      <endeavor-content-query-section-list
+        limit=4
+        section-alias="new-products"
+        header={ title: "New Products", href: "/new-products" }
+      />
+    </div>
     <div class="col-lg-4 mb-block">
       <endeavor-published-content-query-list
         query={
@@ -108,6 +125,13 @@ $ const adSlots = {
         }
         with-image=false
         header={ title: "White Papers", href: "/whitepapers" }
+      />
+    </div>
+    <div class="col-lg-4 mb-block">
+      <endeavor-content-query-section-list
+        limit=4
+        section-alias="special-reports"
+        header={ title: "Special Reports", href: "/special-reports" }
       />
     </div>
   </div>


### PR DESCRIPTION
Create "On Topic" category

Rearrange the content sections on the home page:

https://southcomm.atlassian.net/browse/CS-2977
Under the hero image/article, have "On Topic" and "Instrumentation"
Next row, have “Applications,” “Industries,” and “Current Issue”
Next row, have “Test Issues & Techniques,” “EE Blogs,” and “Online Exclusives”
Next row, have "New Products", "White Papers", and "Special Reports"

Previous:
![screenshot-www evaluationengineering com-2019 09 11-18_40_59](https://user-images.githubusercontent.com/6343242/64740843-a812e580-d4c4-11e9-9033-2ba2f62563cf.png)

New:
![screenshot-0 0 0 0_12151-2019 09 11-18_45_51](https://user-images.githubusercontent.com/6343242/64740848-acd79980-d4c4-11e9-8066-e262d1b4e4f0.png)
