### PR TITLE
2986-BOW updated mag links, current issue to video

### DIFF
--- a/sites/bioopticsworld/config/site.js
+++ b/sites/bioopticsworld/config/site.js
@@ -36,7 +36,7 @@ module.exports = {
     secondary: {
       items: [
         { href: '/subscribe', label: 'Subscribe' },
-        { href: '/magazine', label: 'Magazine' },
+        { href: 'https://www.laserfocusworld.com/magazine', label: 'Magazine', target: '_blank' },
         { href: '/videos', label: 'Videos' },
         { href: '/white-papers', label: 'White Papers' },
         { href: '/webcasts', label: 'Webcasts' },
@@ -67,7 +67,7 @@ module.exports = {
         label: 'Resources',
         items: [
           { href: '/blogs', label: 'Commentary' },
-          { href: '/magazine', label: 'Magazine' },
+          { href: 'https://www.laserfocusworld.com/magazine', label: 'Magazine', target: '_blank' },
           { href: '/videos', label: 'Videos' },
           { href: '/white-papers', label: 'White Papers' },
           { href: '/webcasts', label: 'Webcasts' },

--- a/sites/bioopticsworld/server/templates/index.marko
+++ b/sites/bioopticsworld/server/templates/index.marko
@@ -126,11 +126,12 @@ $ const adSlots = {
       />
     </div>
     <div class="col-lg-4 mb-block">
-      <endeavor-magazine-query-latest-issue
-        publication-id="5ca3894208cf3a56048b4587"
-        header="Current Issue"
-        as-card=true
-        content-count=0
+      <endeavor-published-content-query-list
+        query={
+          contentTypes: ["Video"],
+          limit: 4,
+        }
+        header={ title: "Videos", href: "/videos" }
       />
     </div>
   </div>


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/CS-2986

- Current issue block was replaced with videos
- Magazine links now to go LFW/magazine

Previous:
<img width="1190" alt="Screen Shot 2019-09-13 at 9 06 54 AM" src="https://user-images.githubusercontent.com/6343242/64864897-190de680-d606-11e9-9b7e-4ba48f63c592.png">


New:
<img width="1205" alt="Screen Shot 2019-09-13 at 9 06 38 AM" src="https://user-images.githubusercontent.com/6343242/64864906-1dd29a80-d606-11e9-8ff7-dfcbe5e7cad6.png">
