### PR TITLE
Mundo ad unit overhaul

### DIFF
--- a/sites/mundopmmi/config/ads.js
+++ b/sites/mundopmmi/config/ads.js
@@ -1,55 +1,19 @@
 const LB = {
-  size: [[970, 250], [970, 90], [970, 66], [728, 90], [320, 50], [300, 50], [300, 100]],
+  size: [[970, 250], [970, 90], [728, 90], [320, 50], [300, 50], [300, 100]],
   sizeMapping: [
-    { viewport: [980, 0], size: [[970, 250], [970, 90], [970, 66], [728, 90]] },
+    { viewport: [980, 0], size: [[970, 250], [970, 90], [728, 90]] },
     { viewport: [750, 0], size: [728, 90] },
     { viewport: [320, 0], size: [[300, 50], [320, 50], [300, 100]] },
   ],
 };
-const CONTENT = {
-  size: [[300, 250], [300, 600]],
-};
-const RESKIN = {};
-const WA = {};
 
-const path = unit => `/152023730/Mundo/${unit}`;
+const path = unit => `/152023730/${unit}`;
 
 module.exports = {
   default: {
-    lb1: { ...LB, path: path('default_lb1') },
-    lb2: { ...LB, path: path('default_lb2') },
-    rail1: { ...CONTENT, path: path('default_rail1') },
-    rail2: { ...CONTENT, path: path('default_rail2') },
-    imu: { ...CONTENT, path: path('default_imu') },
-    hp: { ...CONTENT, path: path('default_hp') },
-    reskin: { ...RESKIN, path: path('default_reskin') },
-    wa: { ...WA, path: path('default_wa') },
-  },
-  automatizacion: {
-    lb1: { ...LB, path: path('automatizacion_lb1') },
-    lb2: { ...LB, path: path('automatizacion_lb2') },
-    rail1: { ...CONTENT, path: path('automatizacion_rail1') },
-    rail2: { ...CONTENT, path: path('automatizacion_rail2') },
-    imu: { ...CONTENT, path: path('automatizacion_imu') },
-    hp: { ...CONTENT, path: path('automatizacion_hp') },
-    reskin: { ...RESKIN, path: path('automatizacion_reskin') },
-  },
-  empaque: {
-    lb1: { ...LB, path: path('empaque_lb1') },
-    lb2: { ...LB, path: path('empaque_lb2') },
-    rail1: { ...CONTENT, path: path('empaque_rail1') },
-    rail2: { ...CONTENT, path: path('empaque_rail2') },
-    imu: { ...CONTENT, path: path('empaque_imu') },
-    hp: { ...CONTENT, path: path('empaque_hp') },
-    reskin: { ...RESKIN, path: path('empaque_reskin') },
-  },
-  procesamiento: {
-    lb1: { ...LB, path: path('procesamiento_lb1') },
-    lb2: { ...LB, path: path('procesamiento_lb2') },
-    rail1: { ...CONTENT, path: path('procesamiento_rail1') },
-    rail2: { ...CONTENT, path: path('procesamiento_rail2') },
-    imu: { ...CONTENT, path: path('procesamiento_imu') },
-    hp: { ...CONTENT, path: path('procesamiento_hp') },
-    reskin: { ...RESKIN, path: path('procesamiento_reskin') },
+    leaderboard: { ...LB, path: path('mundo_leaderboard') },
+    imu1: { size: [300, 250], path: path('mundo_imu1') },
+    imu2: { size: [300, 250], path: path('mundo_imu2') },
+    skyscraper: { size: [300, 600], path: path('mundo_skyscraper') },
   },
 };

--- a/sites/mundopmmi/server/templates/content/components/pre-load-more-layout.marko
+++ b/sites/mundopmmi/server/templates/content/components/pre-load-more-layout.marko
@@ -16,8 +16,7 @@ $ const { nodes, header, aliases } = input;
     </div>
     <div class="col-md-6 col-lg-4">
       <endeavor-gam-ad-unit-define-display
-        name="hp"
-        size=[300, 600]
+        name="skyscraper"
         aliases=aliases
       />
     </div>

--- a/sites/mundopmmi/server/templates/content/index.marko
+++ b/sites/mundopmmi/server/templates/content/index.marko
@@ -9,8 +9,8 @@ $ const section = getAsObject(content, 'primarySection');
 $ const aliases = hierarchyAliases(section);
 $ const block = 'content-page';
 $ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1', aliases }),
-  'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases, size: [300, 250] }),
+  'gpt-ad-leaderboard': getAdUnit(site, { name: 'leaderboard', aliases }),
+  'gpt-ad-imu1': getAdUnit(site, { name: 'imu1', aliases }),
 };
 $ const displayPrimaryImage = ['whitepaper', 'media-gallery'].includes(content.type) ? false : true;
 $ const displayRailAds = ['contact', 'company'].includes(content.type) ? false : true;
@@ -21,12 +21,7 @@ $ const displayRailRelatedContent = false;
     <endeavor-ad-gam-head slots=adSlots targeting={ cont_id: content.id, cont_type: content.type } />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-display id="gpt-ad-leaderboard" modifiers=["top-of-page"] />
 
   <div class="page-wrapper">
     <div class="row">
@@ -47,7 +42,7 @@ $ const displayRailRelatedContent = false;
 
       <aside class="col-lg-4 page-right-rail">
         <if(displayRailAds)>
-          <endeavor-gam-ad-unit-display id="gpt-ad-rail1" />
+          <endeavor-gam-ad-unit-display id="gpt-ad-imu1" />
         </if>
         <div id="gtm-content-rail1"></div>
         <if(displayRailRelatedContent)>

--- a/sites/mundopmmi/server/templates/dynamic-page/index.marko
+++ b/sites/mundopmmi/server/templates/dynamic-page/index.marko
@@ -6,12 +6,8 @@ $ const page = getAsObject(data, 'page');
   <@head>
     <endeavor-ad-gam-head />
   </@head>
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@above-container>
 
-  <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-define-display name="leaderboard" modifiers=["top-of-page"] />
 
   <div class="page-wrapper">
     <div class="row">

--- a/sites/mundopmmi/server/templates/index.marko
+++ b/sites/mundopmmi/server/templates/index.marko
@@ -9,8 +9,8 @@ $ const section = getAsObject(data, 'section');
 $ const aliases = hierarchyAliases(section);
 $ const sections = site.getAsArray('homeSections');
 $ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1', aliases }),
-  'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases, size: [300, 600] }),
+  'gpt-ad-leaderboard': getAdUnit(site, { name: 'leaderboard', aliases }),
+  'gpt-ad-skyscraper': getAdUnit(site, { name: 'skyscraper', aliases }),
 };
 
 <theme-default-website-section-layout section=section>
@@ -18,12 +18,7 @@ $ const adSlots = {
     <endeavor-ad-gam-head slots=adSlots />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-display id="gpt-ad-leaderboard" modifiers=["top-of-page"] />
 
   <endeavor-content-query-hero
     section-id=section.id
@@ -41,7 +36,7 @@ $ const adSlots = {
       />
     </div>
     <div class="col-lg-4 ad-rail">
-      <endeavor-gam-ad-unit-display id="gpt-ad-rail2" />
+      <endeavor-gam-ad-unit-display id="gpt-ad-skyscraper" />
     </div>
   </div>
 

--- a/sites/mundopmmi/server/templates/magazine/index.marko
+++ b/sites/mundopmmi/server/templates/magazine/index.marko
@@ -6,12 +6,7 @@ $ const description = site.get('magazines.description');
     <endeavor-ad-gam-head />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-define-display name="leaderboard" modifiers=["top-of-page"] />
 
   <div class="page-wrapper">
     <div class="row">

--- a/sites/mundopmmi/server/templates/magazine/issue.marko
+++ b/sites/mundopmmi/server/templates/magazine/issue.marko
@@ -8,12 +8,7 @@ $ const publication = getAsObject(issue, 'publication');
     <endeavor-ad-gam-head />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-define-display name="leaderboard" modifiers=["top-of-page"] />
 
   <div class="page-wrapper">
     <div class="row">

--- a/sites/mundopmmi/server/templates/magazine/publication.marko
+++ b/sites/mundopmmi/server/templates/magazine/publication.marko
@@ -7,12 +7,7 @@ $ const publication = getAsObject(data, 'publication');
     <endeavor-ad-gam-head />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-define-display name="leaderboard" modifiers=["top-of-page"] />
 
   <div class="page-wrapper">
     <div class="row">

--- a/sites/mundopmmi/server/templates/published-content/videos.marko
+++ b/sites/mundopmmi/server/templates/published-content/videos.marko
@@ -12,12 +12,7 @@ $ const page = {
     <endeavor-ad-gam-head />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-define-display name="leaderboard" modifiers=["top-of-page"] />
 
   <div class="page-wrapper">
     <div class="row">

--- a/sites/mundopmmi/server/templates/published-content/webinars.marko
+++ b/sites/mundopmmi/server/templates/published-content/webinars.marko
@@ -14,12 +14,7 @@ $ const page = pageDetails('Webcasts', config);
     <endeavor-ad-gam-head />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-define-display name="leaderboard" modifiers=["top-of-page"] />
 
   <div class="page-wrapper">
     <div class="row">

--- a/sites/mundopmmi/server/templates/published-content/white-papers.marko
+++ b/sites/mundopmmi/server/templates/published-content/white-papers.marko
@@ -9,12 +9,7 @@ $ const page = pageDetails('White Papers', config);
     <endeavor-ad-gam-head />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-define-display name="leaderboard" modifiers=["top-of-page"] />
 
   <div class="page-wrapper">
     <div class="row">

--- a/sites/mundopmmi/server/templates/search.marko
+++ b/sites/mundopmmi/server/templates/search.marko
@@ -5,12 +5,7 @@ $ const { site, config } = out.global;
     <endeavor-ad-gam-head />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-define-display name="leaderboard" modifiers=["top-of-page"] />
 
   <div class="page-wrapper">
     <div class="row">

--- a/sites/mundopmmi/server/templates/subscribe/email.marko
+++ b/sites/mundopmmi/server/templates/subscribe/email.marko
@@ -5,12 +5,7 @@ import { get, getAsObject } from '@base-cms/object-path';
     <endeavor-ad-gam-head />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-define-display name="leaderboard" modifiers=["top-of-page"] />
 
   <div class="page-wrapper">
     <div class="row">

--- a/sites/mundopmmi/server/templates/subscribe/index.marko
+++ b/sites/mundopmmi/server/templates/subscribe/index.marko
@@ -10,12 +10,7 @@ $ const newsletterDescription = 'Stay up-to-date on industry news and events, ne
     <endeavor-ad-gam-head />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-define-display name="leaderboard" modifiers=["top-of-page"] />
 
   <div class="page-wrapper">
     <div class="row">

--- a/sites/mundopmmi/server/templates/subscribe/magazine.marko
+++ b/sites/mundopmmi/server/templates/subscribe/magazine.marko
@@ -8,12 +8,7 @@ $ const publication = getAsObject(data, 'publication');
     <endeavor-ad-gam-head />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-define-display name="leaderboard" modifiers=["top-of-page"] />
 
   <div class="page-wrapper">
     <div class="row">

--- a/sites/mundopmmi/server/templates/website-section/automatizacion.marko
+++ b/sites/mundopmmi/server/templates/website-section/automatizacion.marko
@@ -7,8 +7,8 @@ $ const { site } = out.global;
 $ const section = getAsObject(data, 'section');
 $ const aliases = hierarchyAliases(section);
 $ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1', aliases }),
-  'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases, size: [300, 600] }),
+  'gpt-ad-leaderboard': getAdUnit(site, { name: 'leaderboard', aliases }),
+  'gpt-ad-skyscraper': getAdUnit(site, { name: 'skyscraper', aliases }),
 };
 
 <theme-default-website-section-layout section=section>
@@ -16,12 +16,7 @@ $ const adSlots = {
     <endeavor-ad-gam-head slots=adSlots />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-display id="gpt-ad-leaderboard" modifiers=["top-of-page"] />
 
   <endeavor-content-query-hero
     section-id=section.id
@@ -45,7 +40,7 @@ $ const adSlots = {
       />
     </div>
     <div class="col-lg-4 ad-rail">
-      <endeavor-gam-ad-unit-display id="gpt-ad-rail2" />
+      <endeavor-gam-ad-unit-display id="gpt-ad-skyscraper" />
     </div>
   </div>
 

--- a/sites/mundopmmi/server/templates/website-section/companias.marko
+++ b/sites/mundopmmi/server/templates/website-section/companias.marko
@@ -8,12 +8,7 @@ $ const section = getAsObject(data, 'section');
     <endeavor-ad-gam-head />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-define-display name="leaderboard" modifiers=["top-of-page"] />
 
   <div class="page-wrapper mb-block">
     <div class="row">

--- a/sites/mundopmmi/server/templates/website-section/components/pre-load-more-layout.marko
+++ b/sites/mundopmmi/server/templates/website-section/components/pre-load-more-layout.marko
@@ -11,16 +11,14 @@ $ const { nodes, header, aliases } = input;
   <endeavor-item-card-deck|{ item }| items=nodes>
     <@slot position="after" index=1>
       <endeavor-gam-ad-unit-define-display
-        name="imu"
-        size=[300, 250]
+        name="imu1"
         aliases=aliases
         modifiers=["in-card"]
       />
     </@slot>
     <@slot position="after" index=4>
       <endeavor-gam-ad-unit-define-display
-        name="imu"
-        size=[300, 250]
+        name="imu2"
         aliases=aliases
         modifiers=["in-card"]
       />

--- a/sites/mundopmmi/server/templates/website-section/contact-us.marko
+++ b/sites/mundopmmi/server/templates/website-section/contact-us.marko
@@ -15,12 +15,7 @@ $ const query = {
     <script src="https://www.google.com/recaptcha/api.js?onload=vueRecaptchaApiLoaded&render=explicit" async defer></script>
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-define-display name="leaderboard" modifiers=["top-of-page"] />
 
   <div class="page-wrapper">
     <div class="row">

--- a/sites/mundopmmi/server/templates/website-section/empaque.marko
+++ b/sites/mundopmmi/server/templates/website-section/empaque.marko
@@ -7,8 +7,8 @@ $ const { site } = out.global;
 $ const section = getAsObject(data, 'section');
 $ const aliases = hierarchyAliases(section);
 $ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1', aliases }),
-  'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases, size: [300, 600] }),
+  'gpt-ad-leaderboard': getAdUnit(site, { name: 'leaderboard', aliases }),
+  'gpt-ad-skyscraper': getAdUnit(site, { name: 'skyscraper', aliases }),
 };
 
 <theme-default-website-section-layout section=section>
@@ -16,12 +16,7 @@ $ const adSlots = {
     <endeavor-ad-gam-head slots=adSlots />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-display id="gpt-ad-leaderboard" modifiers=["top-of-page"] />
 
   <endeavor-content-query-hero
     section-id=section.id
@@ -45,7 +40,7 @@ $ const adSlots = {
       />
     </div>
     <div class="col-lg-4 ad-rail">
-      <endeavor-gam-ad-unit-display id="gpt-ad-rail2" />
+      <endeavor-gam-ad-unit-display id="gpt-ad-skyscraper" />
     </div>
   </div>
 

--- a/sites/mundopmmi/server/templates/website-section/eventos.marko
+++ b/sites/mundopmmi/server/templates/website-section/eventos.marko
@@ -8,12 +8,7 @@ $ const section = getAsObject(data, 'section');
     <endeavor-ad-gam-head />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-define-display name="lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-define-display name="leaderboard" modifiers=["top-of-page"] />
 
   <div class="page-wrapper mb-block">
     <div class="row">

--- a/sites/mundopmmi/server/templates/website-section/index.marko
+++ b/sites/mundopmmi/server/templates/website-section/index.marko
@@ -7,9 +7,9 @@ $ const { site } = out.global;
 $ const section = getAsObject(data, 'section');
 $ const aliases = hierarchyAliases(section);
 $ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1', aliases }),
-  'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases, size: [300, 250] }),
-  'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases, size: [300, 600] }),
+  'gpt-ad-leaderboard': getAdUnit(site, { name: 'leaderboard', aliases }),
+  'gpt-ad-imu1': getAdUnit(site, { name: 'imu1', aliases, size: [300, 250] }),
+  'gpt-ad-skyscraper': getAdUnit(site, { name: 'skyscraper', aliases, size: [300, 600] }),
 };
 
 <theme-default-website-section-layout section=section>
@@ -17,12 +17,7 @@ $ const adSlots = {
     <endeavor-ad-gam-head slots=adSlots />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-display id="gpt-ad-leaderboard" modifiers=["top-of-page"] />
 
   <endeavor-content-query-hero
     section-id=section.id
@@ -40,8 +35,8 @@ $ const adSlots = {
       />
     </div>
     <div class="col-lg-4 ad-rail">
-      <endeavor-gam-ad-unit-display id="gpt-ad-rail1" />
-      <endeavor-gam-ad-unit-display id="gpt-ad-rail2" />
+      <endeavor-gam-ad-unit-display id="gpt-ad-imu1" />
+      <endeavor-gam-ad-unit-display id="gpt-ad-skyscraper" />
     </div>
   </div>
 

--- a/sites/mundopmmi/server/templates/website-section/procesamiento.marko
+++ b/sites/mundopmmi/server/templates/website-section/procesamiento.marko
@@ -7,8 +7,8 @@ $ const { site } = out.global;
 $ const section = getAsObject(data, 'section');
 $ const aliases = hierarchyAliases(section);
 $ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1', aliases }),
-  'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases, size: [300, 600] }),
+  'gpt-ad-leaderboard': getAdUnit(site, { name: 'leaderboard', aliases }),
+  'gpt-ad-skyscraper': getAdUnit(site, { name: 'skyscraper', aliases }),
 };
 
 <theme-default-website-section-layout section=section>
@@ -16,12 +16,7 @@ $ const adSlots = {
     <endeavor-ad-gam-head slots=adSlots />
   </@head>
 
-  <@above-container>
-    <endeavor-gam-ad-unit-out-of-page name="wa" aliases=aliases />
-    <endeavor-gam-ad-unit-out-of-page name="reskin" aliases=aliases />
-  </@above-container>
-
-  <endeavor-gam-ad-unit-display id="gpt-ad-lb1" modifiers=["top-of-page"] />
+  <endeavor-gam-ad-unit-display id="gpt-ad-leaderboard" modifiers=["top-of-page"] />
 
   <endeavor-content-query-hero
     section-id=section.id
@@ -45,7 +40,7 @@ $ const adSlots = {
       />
     </div>
     <div class="col-lg-4 ad-rail">
-      <endeavor-gam-ad-unit-display id="gpt-ad-rail2" />
+      <endeavor-gam-ad-unit-display id="gpt-ad-skyscraper" />
     </div>
   </div>
 


### PR DESCRIPTION
- Dropped WA and RESKIN ad units
- Renamed units throughout to match their naming conventions and flattened structure

![mundo-home](https://user-images.githubusercontent.com/2855198/65150414-b479cf80-d9e9-11e9-91d6-b72e8dbeb636.jpg)
![Screen Shot 2019-09-18 at 7 54 18 AM](https://user-images.githubusercontent.com/2855198/65150424-ba6fb080-d9e9-11e9-998e-fac9f7994bcf.png)
