### PR TITLE
Basecamp: Correct reveal ad overlaying footer

### DIFF
--- a/packages/themes/default/styles/theme/_footer.scss
+++ b/packages/themes/default/styles/theme/_footer.scss
@@ -6,6 +6,7 @@
   line-height: $theme-site-footer-line-height;
   box-shadow: $theme-site-footer-box-shadow;
   opacity: $theme-site-footer-opacity;
+  z-index: 1; //needed to prevent reveal ad from overlaying footer
 
   &__container {
     @include make-container();

--- a/packages/themes/default/styles/theme/_footer.scss
+++ b/packages/themes/default/styles/theme/_footer.scss
@@ -1,4 +1,5 @@
 .site-footer {
+  z-index: 1; //needed to prevent reveal ad from overlaying footer
   margin-top: auto;
   font-family: $theme-site-footer-font-family;
   font-size: $theme-site-footer-font-size;
@@ -6,7 +7,6 @@
   line-height: $theme-site-footer-line-height;
   box-shadow: $theme-site-footer-box-shadow;
   opacity: $theme-site-footer-opacity;
-  z-index: 1; //needed to prevent reveal ad from overlaying footer
 
   &__container {
     @include make-container();


### PR DESCRIPTION
https://3.basecamp.com/4053736/buckets/13399348/todos/2097368958

Current:
<img width="1437" alt="Screen Shot 2019-10-02 at 2 56 30 PM" src="https://user-images.githubusercontent.com/6343242/66077162-03188500-e525-11e9-97f7-052eebd11f1d.png">

New:
<img width="1440" alt="Screen Shot 2019-10-02 at 2 56 15 PM" src="https://user-images.githubusercontent.com/6343242/66077170-09a6fc80-e525-11e9-973a-8e42b9fec586.png">
