### PR TITLE
Fixed BZB redirect loop

### DIFF
--- a/sites/bizbash/index.js
+++ b/sites/bizbash/index.js
@@ -20,7 +20,7 @@ module.exports = startServer({
   redirectHandler: ({ from }) => {
     const pattern = /(\/story\/[0-9]*|\/listing\/[0-9]*|\/gallery\/[0-9]*)/;
     const matches = pattern.exec(from);
-    if ((matches || matches[0]) && matches[0] !== matches['input']) return { to: matches[0] };
+    if (matches && matches[0] !== from) return { to: matches[0] };
     return null;
   },
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/bizbash/index.js
+++ b/sites/bizbash/index.js
@@ -20,7 +20,7 @@ module.exports = startServer({
   redirectHandler: ({ from }) => {
     const pattern = /(\/story\/[0-9]*|\/listing\/[0-9]*|\/gallery\/[0-9]*)/;
     const matches = pattern.exec(from);
-    if (!matches || !matches[0]) return null;
-    return { to: matches[0] };
+    if ((matches || matches[0]) && matches[0] !== matches['input']) return { to: matches[0] };
+    return null;
   },
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));


### PR DESCRIPTION
If you go to https://www.bizbash.com/story/12345 it will get stuck in a redirect loop. Some bots are doing this causing extra queries on the database.

The original commit was to allow these types of redirects to work.
https://www.bizbash.com/call_sheet_70_hotel_buyers_from_abroad_event_planners_aid_katrina_victims_affordable_same-sex_wedding_start-up/new-york/story/21181/

which should then redirect to https://www.bizbash.com/story/21181/ but if there is no redirect found it gets stuck in a loop.

Original commit
https://github.com/endeavorb2b/websites/commit/fb616cfd3e75b4a797793e2e4f2d081c64648653

I changed it so that if the input uri is the same as the match for the redirect to ignore it and return null.
