### PR TITLE
Updated OGJ homepage blocks

### DIFF
--- a/sites/ogj/server/templates/index.marko
+++ b/sites/ogj/server/templates/index.marko
@@ -111,7 +111,7 @@ $ const adSlots = {
         header={ title: "General Interest", href: "/general-interest" }
         requires-image=false
         use-placeholder=false
-        native-x={ placement: 'list1', aliases: ['general-interest'], index: 3 }
+        native-x={ placement: "list1", aliases: ["general-interest"], index: 3 }
       />
     </div>
     <div class="col-lg-4 mb-block">
@@ -121,7 +121,7 @@ $ const adSlots = {
         header={ title: "Exploration & Development", href: "/exploration-development" }
         requires-image=false
         use-placeholder=false
-        native-x={ placement: 'list1', aliases: ['exploration-development'], index: 3 }
+        native-x={ placement: "list1", aliases: ["exploration-development"], index: 3 }
       />
     </div>
     <div class="col-lg-4 mb-block">
@@ -131,7 +131,7 @@ $ const adSlots = {
         header={ title: "Drilling & Production", href: "/drilling-production" }
         requires-image=false
         use-placeholder=false
-        native-x={ placement: 'list1', aliases: ['drilling-production'], index: 3 }
+        native-x={ placement: "list1", aliases: ["drilling-production"], index: 3 }
       />
     </div>
   </div>
@@ -144,7 +144,7 @@ $ const adSlots = {
         header={ title: "Refining & Processing", href: "/refining-processing" }
         requires-image=false
         use-placeholder=false
-        native-x={ placement: 'list1', aliases: ['refining-processing'], index: 3 }
+        native-x={ placement: "list1", aliases: ["refining-processing"], index: 3 }
       />
     </div>
     <div class="col-lg-4 mb-block">
@@ -154,7 +154,7 @@ $ const adSlots = {
         header={ title: "Pipelines & Transportation", href: "/pipelines-transportation" }
         requires-image=false
         use-placeholder=false
-        native-x={ placement: 'list1', aliases: ['pipelines-transportation'], index: 3 }
+        native-x={ placement: "list1", aliases: ["pipelines-transportation"], index: 3 }
       />
     </div>
     <div class="col-lg-4 mb-block">
@@ -176,7 +176,7 @@ $ const adSlots = {
         header={ title: "LNG", href: "/pipelines-transportation/lng" }
         requires-image=false
         use-placeholder=false
-        native-x={ placement: 'list1', aliases: ['pipelines-transportation/lng'], index: 3 }
+        native-x={ placement: "list1", aliases: ["pipelines-transportation/lng"], index: 3 }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/ogj/server/templates/index.marko
+++ b/sites/ogj/server/templates/index.marko
@@ -160,22 +160,23 @@ $ const adSlots = {
     <div class="col-lg-4 mb-block">
       <endeavor-content-query-section-list
         limit=4
-        section-alias="editors-perspective"
+        section-alias="covid-19"
         requires-image=false
         use-placeholder=false
-        header={ title: "Editor's Perspective", href: "/editors-perspective" }
+        header={ title: "COVID-19", href: "/covid-19" }
       />
     </div>
   </div>
 
   <div class="row">
     <div class="col-lg-4 mb-block">
-      <endeavor-published-content-query-list
-        query={
-          contentTypes: ["Video"],
-          limit: 4,
-        }
-        header={ title: "Videos", href: "/videos" }
+      <endeavor-content-query-section-list
+        limit=4
+        section-alias="pipelines-transportation/lng"
+        header={ title: "LNG", href: "/pipelines-transportation/lng" }
+        requires-image=false
+        use-placeholder=false
+        native-x={ placement: 'list1', aliases: ['pipelines-transportation/lng'], index: 3 }
       />
     </div>
     <div class="col-lg-4 mb-block">

--- a/sites/ogj/server/templates/index.marko
+++ b/sites/ogj/server/templates/index.marko
@@ -1,15 +1,15 @@
-import { getAsObject } from '@base-cms/object-path';
-import getAdUnit from '@endeavorb2b/base-website-common/utils/gam/get-adunit';
-import hierarchyAliases from '@endeavorb2b/base-website-common/utils/website-section/hierarchy-aliases';
+import { getAsObject } from "@base-cms/object-path";
+import getAdUnit from "@endeavorb2b/base-website-common/utils/gam/get-adunit";
+import hierarchyAliases from "@endeavorb2b/base-website-common/utils/website-section/hierarchy-aliases";
 
 $ const { site } = out.global;
-$ const section = getAsObject(data, 'section');
+$ const section = getAsObject(data, "section");
 $ const aliases = hierarchyAliases(section);
-$ const sections = site.getAsArray('homeSections');
+$ const sections = site.getAsArray("homeSections");
 $ const adSlots = {
-  'gpt-ad-lb1': getAdUnit(site, { name: 'lb1', aliases }),
-  'gpt-ad-rail1': getAdUnit(site, { name: 'rail1', aliases, size: [300, 250] }),
-  'gpt-ad-rail2': getAdUnit(site, { name: 'rail2', aliases, size: [300, 600] }),
+  "gpt-ad-lb1": getAdUnit(site, { name: "lb1", aliases }),
+  "gpt-ad-rail1": getAdUnit(site, { name: "rail1", aliases, size: [300, 250] }),
+  "gpt-ad-rail2": getAdUnit(site, { name: "rail2", aliases, size: [300, 600] }),
 };
 
 <theme-default-website-section-layout section=section>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172246031

Replace “Editor’s Perspective” content well with “COVID-19”
Replace the “Videos” content well with content from the Pipelines-Transportation/LNG section, but title it "LNG"

Current:
<img width="1224" alt="Screen Shot 2020-04-13 at 11 13 53 AM" src="https://user-images.githubusercontent.com/6343242/79132421-4e370e80-7d78-11ea-980e-763fdf731d89.png">
<img width="1211" alt="Screen Shot 2020-04-13 at 11 13 46 AM" src="https://user-images.githubusercontent.com/6343242/79132423-4f683b80-7d78-11ea-865f-daa4217f229f.png">

New:
<img width="1223" alt="Screen Shot 2020-04-13 at 11 13 22 AM" src="https://user-images.githubusercontent.com/6343242/79132439-555e1c80-7d78-11ea-8021-dba1188d5c93.png">
<img width="1199" alt="Screen Shot 2020-04-13 at 11 13 12 AM" src="https://user-images.githubusercontent.com/6343242/79132440-555e1c80-7d78-11ea-82d7-ca37fd2c9083.png">
