### PR TITLE
Adjust isLogo image size on content pages

### DIFF
--- a/packages/common/components/page/body-image.marko
+++ b/packages/common/components/page/body-image.marko
@@ -2,14 +2,26 @@ $ const block = 'page-body-image';
 $ const { image } = input;
 
 <div class=block>
-  <div class=`${block}__wrapper`>
-    <!-- @todo Add support for responsive images / size variance based on context -->
-    <cms-image-element
-      lazyload=input.lazyload
-      obj=image
-      options=input.options
-    />
-  </div>
+  <if(image.isLogo)>
+    <div class="primary-image-inline">
+      <cms-image-element
+        lazyload=input.lazyload
+        obj=image
+        options={ w: 250 }
+        width=250
+      />
+    </div>
+  </if>
+  <else>
+    <div class=`${block}__wrapper`>
+      <!-- @todo Add support for responsive images / size variance based on context -->
+        <cms-image-element
+        lazyload=input.lazyload
+        obj=image
+        options=input.options
+      />
+    </div>
+  </else>
   <cms-text-element tag="div" class=`${block}__caption` field="caption" obj=image asHTML=true />
   <cms-text-element tag="div" class=`${block}__credit` field="credit" obj=image asHTML=true />
 </div>

--- a/packages/themes/default/styles/theme/page/_body-image.scss
+++ b/packages/themes/default/styles/theme/page/_body-image.scss
@@ -17,4 +17,13 @@
       height: auto;
     }
   }
+
+  .primary-image-inline {
+    float: right;
+    max-width: 250px;
+    margin-top: .36842em;
+    margin-bottom: 0;
+    margin-left: .75rem;
+  }
+
 }

--- a/packages/themes/default/styles/theme/page/_body-image.scss
+++ b/packages/themes/default/styles/theme/page/_body-image.scss
@@ -21,7 +21,7 @@
   .primary-image-inline {
     float: right;
     max-width: 250px;
-    margin-top: .36842em;
+    margin-top: calc((#{$theme-page-body-line-height} - 1) * .5em);
     margin-bottom: 0;
     margin-left: .75rem;
   }


### PR DESCRIPTION
If the primary image has isLogo set to `true` then the image will be shrunk down to 250px wide, otherwise it will remain full-width.  

https://southcomm.atlassian.net/browse/DEV-242

isLogo = true:
<img width="1101" alt="Screen Shot 2020-10-07 at 10 53 48 AM" src="https://user-images.githubusercontent.com/12496550/95356596-75d0e480-088c-11eb-8ee0-7d64216bba4d.png">

isLogo = false:
<img width="1143" alt="Screen Shot 2020-10-07 at 10 53 56 AM" src="https://user-images.githubusercontent.com/12496550/95356621-7b2e2f00-088c-11eb-8d05-17507241b981.png">
