### PR TITLE
Update homepage block

### DIFF
--- a/sites/ogj/server/templates/index.marko
+++ b/sites/ogj/server/templates/index.marko
@@ -160,10 +160,10 @@ $ const adSlots = {
     <div class="col-lg-4 mb-block">
       <endeavor-content-query-section-list
         limit=4
-        section-alias="covid-19"
+        section-alias="energy-transition"
         requires-image=false
         use-placeholder=false
-        header={ title: "COVID-19", href: "/covid-19" }
+        header={ title: "Energy Transition", href: "/energy-transition" }
       />
     </div>
   </div>


### PR DESCRIPTION
Replaced “COVID-19” with “Energy Transition” per DEV-559
<img width="1049" alt="Screen Shot 2021-04-09 at 8 40 53 AM" src="https://user-images.githubusercontent.com/12496550/114189343-b7ac1780-990f-11eb-8a70-4ad1284731b1.png">
